### PR TITLE
Add step to login into container registry in CI

### DIFF
--- a/.github/workflows/master-workflow.yaml
+++ b/.github/workflows/master-workflow.yaml
@@ -17,6 +17,12 @@ jobs:
       uses: actions/checkout@v1
     - name: Build golang binary
       run: make build
+    - name: Logging in to container registry
+      uses: azure/docker-login@v1
+      with:
+        login-server: index.docker.io
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
     - name: Build docker image
       run: make docker
     - name: Publish docker image


### PR DESCRIPTION
This step is required to be able to publish to the registry, and if necessary, pull images that aren't public.