### PR TITLE
Replace azure docker login with native command

### DIFF
--- a/.github/workflows/master-workflow.yaml
+++ b/.github/workflows/master-workflow.yaml
@@ -18,11 +18,10 @@ jobs:
     - name: Build golang binary
       run: make build
     - name: Logging in to container registry
-      uses: azure/docker-login@v1
-      with:
-        login-server: index.docker.io
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
     - name: Build docker image
       run: make docker
     - name: Publish docker image


### PR DESCRIPTION
This is to fix weird permission issue that doesn't allow
docker account to push images.

Signed-off-by: Giri Kuncoro <girikuncoro@gmail.com>