### PR TITLE
Add rx tx collector for logical router port

### DIFF
--- a/collector/logical_router_port_collector.go
+++ b/collector/logical_router_port_collector.go
@@ -1,0 +1,174 @@
+package collector
+
+import (
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	nsxt "github.com/vmware/go-vmware-nsxt"
+	"github.com/vmware/go-vmware-nsxt/manager"
+)
+
+func init() {
+	registerCollector("logical_router_port", newLogicalRouterPortCollector)
+}
+
+type logicalRouterPortCollector struct {
+	client *nsxt.APIClient
+	logger log.Logger
+
+	rxTotalPacketDesc   *prometheus.Desc
+	rxDroppedPacketDesc *prometheus.Desc
+	rxTotalByteDesc     *prometheus.Desc
+	txTotalPacketDesc   *prometheus.Desc
+	txDroppedPacketDesc *prometheus.Desc
+	txTotalByteDesc     *prometheus.Desc
+}
+
+func newLogicalRouterPortCollector(client *nsxt.APIClient, logger log.Logger) prometheus.Collector {
+	rxTotalPacketDesc := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "logical_router_port", "rx_total_packet"),
+		"Total packets of logical router port rx",
+		[]string{"id", "name", "logical_router_id"},
+		nil,
+	)
+	rxDroppedPacketDesc := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "logical_router_port", "rx_dropped_packet"),
+		"Total dropped packets of logical router port rx",
+		[]string{"id", "name", "logical_router_id"},
+		nil,
+	)
+	rxTotalByteDesc := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "logical_router_port", "rx_total_byte"),
+		"Total bytes of logical router port rx",
+		[]string{"id", "name", "logical_router_id"},
+		nil,
+	)
+	txTotalPacketDesc := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "logical_router_port", "tx_total_packet"),
+		"Total packets of logical router port tx",
+		[]string{"id", "name", "logical_router_id"},
+		nil,
+	)
+	txDroppedPacketDesc := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "logical_router_port", "tx_dropped_packet"),
+		"Total dropped packets of logical router port tx",
+		[]string{"id", "name", "logical_router_id"},
+		nil,
+	)
+	txTotalByteDesc := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "logical_router_port", "tx_total_byte"),
+		"Total bytes of logical router port tx",
+		[]string{"id", "name", "logical_router_id"},
+		nil,
+	)
+	return &logicalRouterPortCollector{
+		client:              client,
+		logger:              logger,
+		rxTotalPacketDesc:   rxTotalPacketDesc,
+		rxTotalByteDesc:     rxTotalByteDesc,
+		rxDroppedPacketDesc: rxDroppedPacketDesc,
+		txTotalPacketDesc:   txTotalPacketDesc,
+		txTotalByteDesc:     txTotalByteDesc,
+		txDroppedPacketDesc: txDroppedPacketDesc,
+	}
+}
+
+// Describe implements the prometheus.Collector interface.
+func (c *logicalRouterPortCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.rxTotalPacketDesc
+	ch <- c.rxDroppedPacketDesc
+	ch <- c.rxTotalByteDesc
+	ch <- c.txTotalPacketDesc
+	ch <- c.txDroppedPacketDesc
+	ch <- c.txTotalByteDesc
+}
+
+// Collect implements the prometheus.Collector interface.
+func (c *logicalRouterPortCollector) Collect(ch chan<- prometheus.Metric) {
+	logicalRouterPortStatisticMetrics := c.generateLogicalRouterPortStatisticMetrics()
+	for _, metric := range logicalRouterPortStatisticMetrics {
+		ch <- metric
+	}
+}
+
+func (c *logicalRouterPortCollector) generateLogicalRouterPortStatisticMetrics() (logicalRouterPortStatisticMetrics []prometheus.Metric) {
+	var logicalRouterPorts []manager.LogicalRouterPort
+	var cursor string
+	for {
+		localVarOptionals := make(map[string]interface{})
+		localVarOptionals["cursor"] = cursor
+		logicalRouterPortsResult, _, err := c.client.LogicalRoutingAndServicesApi.ListLogicalRouterPorts(c.client.Context, nil)
+		if err != nil {
+			level.Error(c.logger).Log("msg", "Unable to list logical ports", "err", err)
+			return
+		}
+		logicalRouterPorts = append(logicalRouterPorts, logicalRouterPortsResult.Results...)
+		cursor = logicalRouterPortsResult.Cursor
+		if len(cursor) == 0 {
+			break
+		}
+	}
+
+	for _, logicalRouterPort := range logicalRouterPorts {
+		statistic, _, err := c.client.LogicalRoutingAndServicesApi.GetLogicalRouterPortStatisticsSummary(c.client.Context, logicalRouterPort.Id, nil)
+		if err != nil {
+			level.Error(c.logger).Log("msg", "Unable to get logical router port statistics", "id", logicalRouterPort.Id, "err", err)
+			continue
+		}
+		rxTotalPacketMetric := prometheus.MustNewConstMetric(
+			c.rxTotalPacketDesc,
+			prometheus.GaugeValue,
+			float64(statistic.Rx.TotalPackets),
+			logicalRouterPort.Id,
+			logicalRouterPort.DisplayName,
+			logicalRouterPort.LogicalRouterId,
+		)
+		rxDroppedPacketMetric := prometheus.MustNewConstMetric(
+			c.rxDroppedPacketDesc,
+			prometheus.GaugeValue,
+			float64(statistic.Rx.DroppedPackets),
+			logicalRouterPort.Id,
+			logicalRouterPort.DisplayName,
+			logicalRouterPort.LogicalRouterId,
+		)
+		rxTotalByteMetric := prometheus.MustNewConstMetric(
+			c.rxTotalByteDesc,
+			prometheus.GaugeValue,
+			float64(statistic.Rx.TotalBytes),
+			logicalRouterPort.Id,
+			logicalRouterPort.DisplayName,
+			logicalRouterPort.LogicalRouterId,
+		)
+		txTotalPacketMetric := prometheus.MustNewConstMetric(
+			c.txTotalPacketDesc,
+			prometheus.GaugeValue,
+			float64(statistic.Tx.TotalPackets),
+			logicalRouterPort.Id,
+			logicalRouterPort.DisplayName,
+			logicalRouterPort.LogicalRouterId,
+		)
+		txDroppedPacketMetric := prometheus.MustNewConstMetric(
+			c.txDroppedPacketDesc,
+			prometheus.GaugeValue,
+			float64(statistic.Tx.DroppedPackets),
+			logicalRouterPort.Id,
+			logicalRouterPort.DisplayName,
+			logicalRouterPort.LogicalRouterId,
+		)
+		txTotalByteMetric := prometheus.MustNewConstMetric(
+			c.txTotalByteDesc,
+			prometheus.GaugeValue,
+			float64(statistic.Tx.TotalBytes),
+			logicalRouterPort.Id,
+			logicalRouterPort.DisplayName,
+			logicalRouterPort.LogicalRouterId,
+		)
+		logicalRouterPortStatisticMetrics = append(logicalRouterPortStatisticMetrics, rxTotalPacketMetric)
+		logicalRouterPortStatisticMetrics = append(logicalRouterPortStatisticMetrics, rxDroppedPacketMetric)
+		logicalRouterPortStatisticMetrics = append(logicalRouterPortStatisticMetrics, rxTotalByteMetric)
+		logicalRouterPortStatisticMetrics = append(logicalRouterPortStatisticMetrics, txTotalPacketMetric)
+		logicalRouterPortStatisticMetrics = append(logicalRouterPortStatisticMetrics, txDroppedPacketMetric)
+		logicalRouterPortStatisticMetrics = append(logicalRouterPortStatisticMetrics, txTotalByteMetric)
+	}
+	return
+}

--- a/collector/logical_router_port_collector.go
+++ b/collector/logical_router_port_collector.go
@@ -27,37 +27,37 @@ type logicalRouterPortCollector struct {
 func newLogicalRouterPortCollector(client *nsxt.APIClient, logger log.Logger) prometheus.Collector {
 	rxTotalPacket := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "logical_router_port", "rx_total_packet"),
-		"Total packets of logical router port rx",
+		"Total packets received (rx) of logical router port",
 		[]string{"id", "name", "logical_router_id"},
 		nil,
 	)
 	rxDroppedPacket := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "logical_router_port", "rx_dropped_packet"),
-		"Total dropped packets of logical router port rx",
+		"Total receive (rx) packets dropped of logical router port",
 		[]string{"id", "name", "logical_router_id"},
 		nil,
 	)
 	rxTotalByte := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "logical_router_port", "rx_total_byte"),
-		"Total bytes of logical router port rx",
+		"Total bytes received (rx)  of logical router port rx",
 		[]string{"id", "name", "logical_router_id"},
 		nil,
 	)
 	txTotalPacket := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "logical_router_port", "tx_total_packet"),
-		"Total packets of logical router port tx",
+		"Total packets transmitted (rx) of logical router port",
 		[]string{"id", "name", "logical_router_id"},
 		nil,
 	)
 	txDroppedPacket := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "logical_router_port", "tx_dropped_packet"),
-		"Total dropped packets of logical router port tx",
+		"Total transmit (tx) packets dropped of logical router port tx",
 		[]string{"id", "name", "logical_router_id"},
 		nil,
 	)
 	txTotalByte := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "logical_router_port", "tx_total_byte"),
-		"Total bytes of logical router port tx",
+		"Total bytes transmitted (tx) of logical router port",
 		[]string{"id", "name", "logical_router_id"},
 		nil,
 	)

--- a/collector/logical_router_port_collector.go
+++ b/collector/logical_router_port_collector.go
@@ -16,71 +16,71 @@ type logicalRouterPortCollector struct {
 	client *nsxt.APIClient
 	logger log.Logger
 
-	rxTotalPacketDesc   *prometheus.Desc
-	rxDroppedPacketDesc *prometheus.Desc
-	rxTotalByteDesc     *prometheus.Desc
-	txTotalPacketDesc   *prometheus.Desc
-	txDroppedPacketDesc *prometheus.Desc
-	txTotalByteDesc     *prometheus.Desc
+	rxTotalPacket   *prometheus.Desc
+	rxDroppedPacket *prometheus.Desc
+	rxTotalByte     *prometheus.Desc
+	txTotalPacket   *prometheus.Desc
+	txDroppedPacket *prometheus.Desc
+	txTotalByte     *prometheus.Desc
 }
 
 func newLogicalRouterPortCollector(client *nsxt.APIClient, logger log.Logger) prometheus.Collector {
-	rxTotalPacketDesc := prometheus.NewDesc(
+	rxTotalPacket := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "logical_router_port", "rx_total_packet"),
 		"Total packets of logical router port rx",
 		[]string{"id", "name", "logical_router_id"},
 		nil,
 	)
-	rxDroppedPacketDesc := prometheus.NewDesc(
+	rxDroppedPacket := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "logical_router_port", "rx_dropped_packet"),
 		"Total dropped packets of logical router port rx",
 		[]string{"id", "name", "logical_router_id"},
 		nil,
 	)
-	rxTotalByteDesc := prometheus.NewDesc(
+	rxTotalByte := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "logical_router_port", "rx_total_byte"),
 		"Total bytes of logical router port rx",
 		[]string{"id", "name", "logical_router_id"},
 		nil,
 	)
-	txTotalPacketDesc := prometheus.NewDesc(
+	txTotalPacket := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "logical_router_port", "tx_total_packet"),
 		"Total packets of logical router port tx",
 		[]string{"id", "name", "logical_router_id"},
 		nil,
 	)
-	txDroppedPacketDesc := prometheus.NewDesc(
+	txDroppedPacket := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "logical_router_port", "tx_dropped_packet"),
 		"Total dropped packets of logical router port tx",
 		[]string{"id", "name", "logical_router_id"},
 		nil,
 	)
-	txTotalByteDesc := prometheus.NewDesc(
+	txTotalByte := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "logical_router_port", "tx_total_byte"),
 		"Total bytes of logical router port tx",
 		[]string{"id", "name", "logical_router_id"},
 		nil,
 	)
 	return &logicalRouterPortCollector{
-		client:              client,
-		logger:              logger,
-		rxTotalPacketDesc:   rxTotalPacketDesc,
-		rxTotalByteDesc:     rxTotalByteDesc,
-		rxDroppedPacketDesc: rxDroppedPacketDesc,
-		txTotalPacketDesc:   txTotalPacketDesc,
-		txTotalByteDesc:     txTotalByteDesc,
-		txDroppedPacketDesc: txDroppedPacketDesc,
+		client:          client,
+		logger:          logger,
+		rxTotalPacket:   rxTotalPacket,
+		rxTotalByte:     rxTotalByte,
+		rxDroppedPacket: rxDroppedPacket,
+		txTotalPacket:   txTotalPacket,
+		txTotalByte:     txTotalByte,
+		txDroppedPacket: txDroppedPacket,
 	}
 }
 
 // Describe implements the prometheus.Collector interface.
 func (c *logicalRouterPortCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- c.rxTotalPacketDesc
-	ch <- c.rxDroppedPacketDesc
-	ch <- c.rxTotalByteDesc
-	ch <- c.txTotalPacketDesc
-	ch <- c.txDroppedPacketDesc
-	ch <- c.txTotalByteDesc
+	ch <- c.rxTotalPacket
+	ch <- c.rxDroppedPacket
+	ch <- c.rxTotalByte
+	ch <- c.txTotalPacket
+	ch <- c.txDroppedPacket
+	ch <- c.txTotalByte
 }
 
 // Collect implements the prometheus.Collector interface.
@@ -116,7 +116,7 @@ func (c *logicalRouterPortCollector) generateLogicalRouterPortStatisticMetrics()
 			continue
 		}
 		rxTotalPacketMetric := prometheus.MustNewConstMetric(
-			c.rxTotalPacketDesc,
+			c.rxTotalPacket,
 			prometheus.GaugeValue,
 			float64(statistic.Rx.TotalPackets),
 			logicalRouterPort.Id,
@@ -124,7 +124,7 @@ func (c *logicalRouterPortCollector) generateLogicalRouterPortStatisticMetrics()
 			logicalRouterPort.LogicalRouterId,
 		)
 		rxDroppedPacketMetric := prometheus.MustNewConstMetric(
-			c.rxDroppedPacketDesc,
+			c.rxDroppedPacket,
 			prometheus.GaugeValue,
 			float64(statistic.Rx.DroppedPackets),
 			logicalRouterPort.Id,
@@ -132,7 +132,7 @@ func (c *logicalRouterPortCollector) generateLogicalRouterPortStatisticMetrics()
 			logicalRouterPort.LogicalRouterId,
 		)
 		rxTotalByteMetric := prometheus.MustNewConstMetric(
-			c.rxTotalByteDesc,
+			c.rxTotalByte,
 			prometheus.GaugeValue,
 			float64(statistic.Rx.TotalBytes),
 			logicalRouterPort.Id,
@@ -140,7 +140,7 @@ func (c *logicalRouterPortCollector) generateLogicalRouterPortStatisticMetrics()
 			logicalRouterPort.LogicalRouterId,
 		)
 		txTotalPacketMetric := prometheus.MustNewConstMetric(
-			c.txTotalPacketDesc,
+			c.txTotalPacket,
 			prometheus.GaugeValue,
 			float64(statistic.Tx.TotalPackets),
 			logicalRouterPort.Id,
@@ -148,7 +148,7 @@ func (c *logicalRouterPortCollector) generateLogicalRouterPortStatisticMetrics()
 			logicalRouterPort.LogicalRouterId,
 		)
 		txDroppedPacketMetric := prometheus.MustNewConstMetric(
-			c.txDroppedPacketDesc,
+			c.txDroppedPacket,
 			prometheus.GaugeValue,
 			float64(statistic.Tx.DroppedPackets),
 			logicalRouterPort.Id,
@@ -156,7 +156,7 @@ func (c *logicalRouterPortCollector) generateLogicalRouterPortStatisticMetrics()
 			logicalRouterPort.LogicalRouterId,
 		)
 		txTotalByteMetric := prometheus.MustNewConstMetric(
-			c.txTotalByteDesc,
+			c.txTotalByte,
 			prometheus.GaugeValue,
 			float64(statistic.Tx.TotalBytes),
 			logicalRouterPort.Id,


### PR DESCRIPTION
This collector calls NSX logical router port API group to get the rx tx of all logical router ports. 
This PR address #17 

Signed-off-by: William Albertus Dembo <w.albertusd@gmail.com>