### PR TITLE
NSXT Client abstraction for Logical Port Collector

### DIFF
--- a/client/logical_port_client.go
+++ b/client/logical_port_client.go
@@ -1,0 +1,11 @@
+package client
+
+import (
+	"github.com/vmware/go-vmware-nsxt/manager"
+)
+
+type LogicalPortClient interface {
+	ListLogicalPorts(localVarOptionals map[string]interface{}) (manager.LogicalPortListResult, error)
+	GetLogicalPortStatusSummary(localVarOptionals map[string]interface{}) (manager.LogicalPortStatusSummary, error)
+	GetLogicalPortOperationalStatus(lportId string, localVarOptionals map[string]interface{}) (manager.LogicalPortOperationalStatus, error)
+}

--- a/client/nsxt_client.go
+++ b/client/nsxt_client.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"github.com/go-kit/kit/log"
+	nsxt "github.com/vmware/go-vmware-nsxt"
+	"github.com/vmware/go-vmware-nsxt/manager"
+)
+
+type nsxtClient struct {
+	apiClient *nsxt.APIClient
+	logger    log.Logger
+}
+
+func NewNSXTClient(apiClient *nsxt.APIClient, logger log.Logger) *nsxtClient {
+	return &nsxtClient{
+		apiClient: apiClient,
+		logger:    logger,
+	}
+}
+
+func (c *nsxtClient) GetLogicalPortStatusSummary(localVarOptionals map[string]interface{}) (manager.LogicalPortStatusSummary, error) {
+	lportStatus, _, err := c.apiClient.LogicalSwitchingApi.GetLogicalPortStatusSummary(c.apiClient.Context, localVarOptionals)
+	return lportStatus, err
+}
+
+func (c *nsxtClient) ListLogicalPorts(localVarOptionals map[string]interface{}) (manager.LogicalPortListResult, error) {
+	lportsResult, _, err := c.apiClient.LogicalSwitchingApi.ListLogicalPorts(c.apiClient.Context, localVarOptionals)
+	return lportsResult, err
+}
+
+func (c *nsxtClient) GetLogicalPortOperationalStatus(lportId string, localVarOptionals map[string]interface{}) (manager.LogicalPortOperationalStatus, error) {
+	lportStatus, _, err := c.apiClient.LogicalSwitchingApi.GetLogicalPortOperationalStatus(c.apiClient.Context, lportId, localVarOptionals)
+	return lportStatus, err
+}

--- a/client/types.go
+++ b/client/types.go
@@ -1,8 +1,6 @@
 package client
 
-import (
-	"github.com/vmware/go-vmware-nsxt/manager"
-)
+import "github.com/vmware/go-vmware-nsxt/manager"
 
 type LogicalPortClient interface {
 	ListLogicalPorts(localVarOptionals map[string]interface{}) (manager.LogicalPortListResult, error)


### PR DESCRIPTION
Abstract out NSXT client for the logical port collector. This change will make logical port client mockable and more compact interface.

This PR helps on #2 