### PR TITLE
Replace the use of nsxtClient with interface for DHCP collector

### DIFF
--- a/client/nsxt_client.go
+++ b/client/nsxt_client.go
@@ -32,3 +32,13 @@ func (c *nsxtClient) GetLogicalPortOperationalStatus(lportId string, localVarOpt
 	lportStatus, _, err := c.apiClient.LogicalSwitchingApi.GetLogicalPortOperationalStatus(c.apiClient.Context, lportId, localVarOptionals)
 	return lportStatus, err
 }
+
+func (c *nsxtClient) ListDhcpServers(localVarOptionals map[string]interface{}) (manager.LogicalDhcpServerListResult, error) {
+	dhcpServersResult, _, err := c.apiClient.ServicesApi.ListDhcpServers(c.apiClient.Context, localVarOptionals)
+	return dhcpServersResult, err
+}
+
+func (c *nsxtClient) GetDhcpStatus(dhcpID string, localVarOptionals map[string]interface{}) (manager.DhcpServerStatus, error) {
+	dhcpServerStatus, _, err := c.apiClient.ServicesApi.GetDhcpStatus(c.apiClient.Context, dhcpID)
+	return dhcpServerStatus, err
+}

--- a/client/types.go
+++ b/client/types.go
@@ -2,8 +2,15 @@ package client
 
 import "github.com/vmware/go-vmware-nsxt/manager"
 
+// LogicalPortClient represents API group logical port for NSX-T client.
 type LogicalPortClient interface {
 	ListLogicalPorts(localVarOptionals map[string]interface{}) (manager.LogicalPortListResult, error)
 	GetLogicalPortStatusSummary(localVarOptionals map[string]interface{}) (manager.LogicalPortStatusSummary, error)
 	GetLogicalPortOperationalStatus(lportId string, localVarOptionals map[string]interface{}) (manager.LogicalPortOperationalStatus, error)
+}
+
+// DHCPClient represents API group DHCP for NSX-T client.
+type DHCPClient interface {
+	ListDhcpServers(localVarOptionals map[string]interface{}) (manager.LogicalDhcpServerListResult, error)
+	GetDhcpStatus(dhcpID string, localVarOptionals map[string]interface{}) (manager.DhcpServerStatus, error)
 }


### PR DESCRIPTION
The nsxtClient has an interface now for easy pluggability. This commit
introduces the use of interface for DHCP collector.

Signed-off-by: Giri Kuncoro <girikuncoro@gmail.com>