### PR TITLE
Add transport node collector to collect health status of transport node

### DIFF
--- a/client/nsxt_client.go
+++ b/client/nsxt_client.go
@@ -48,7 +48,7 @@ func (c *nsxtClient) ListTransportNodes(localVarOptionals map[string]interface{}
 	return transportNodeStatus, err
 }
 
-func (c *nsxtClient) GetTransportNodeStatus(nodeID string, localVarOptionals map[string]interface{}) (manager.TransportNodeStatus, error) {
-	transportNodeStatus, _, err := c.apiClient.TroubleshootingAndMonitoringApi.GetTransportNodeStatus(c.apiClient.Context, nodeID, localVarOptionals)
+func (c *nsxtClient) GetTransportNodeStatus(nodeID string) (manager.TransportNodeStatus, error) {
+	transportNodeStatus, _, err := c.apiClient.TroubleshootingAndMonitoringApi.GetTransportNodeStatus(c.apiClient.Context, nodeID, nil)
 	return transportNodeStatus, err
 }

--- a/client/nsxt_client.go
+++ b/client/nsxt_client.go
@@ -48,7 +48,7 @@ func (c *nsxtClient) ListTransportNodes(localVarOptionals map[string]interface{}
 	return transportNodeStatus, err
 }
 
-func (c *nsxtClient) GetTransportNodeStatus(nodeId string, localVarOptionals map[string]interface{}) (manager.TransportNodeStatus, error) {
-	transportNodeStatus, _, err := c.apiClient.TroubleshootingAndMonitoringApi.GetTransportNodeStatus(c.apiClient.Context, nodeId, localVarOptionals)
+func (c *nsxtClient) GetTransportNodeStatus(nodeID string, localVarOptionals map[string]interface{}) (manager.TransportNodeStatus, error) {
+	transportNodeStatus, _, err := c.apiClient.TroubleshootingAndMonitoringApi.GetTransportNodeStatus(c.apiClient.Context, nodeID, localVarOptionals)
 	return transportNodeStatus, err
 }

--- a/client/nsxt_client.go
+++ b/client/nsxt_client.go
@@ -42,3 +42,13 @@ func (c *nsxtClient) GetDhcpStatus(dhcpID string, localVarOptionals map[string]i
 	dhcpServerStatus, _, err := c.apiClient.ServicesApi.GetDhcpStatus(c.apiClient.Context, dhcpID)
 	return dhcpServerStatus, err
 }
+
+func (c *nsxtClient) ListTransportNodes(localVarOptionals map[string]interface{}) (manager.TransportNodeListResult, error) {
+	transportNodeStatus, _, err := c.apiClient.NetworkTransportApi.ListTransportNodes(c.apiClient.Context, localVarOptionals)
+	return transportNodeStatus, err
+}
+
+func (c *nsxtClient) GetTransportNodeStatus(nodeId string, localVarOptionals map[string]interface{}) (manager.TransportNodeStatus, error) {
+	transportNodeStatus, _, err := c.apiClient.TroubleshootingAndMonitoringApi.GetTransportNodeStatus(c.apiClient.Context, nodeId, localVarOptionals)
+	return transportNodeStatus, err
+}

--- a/client/types.go
+++ b/client/types.go
@@ -14,3 +14,9 @@ type DHCPClient interface {
 	ListDhcpServers(localVarOptionals map[string]interface{}) (manager.LogicalDhcpServerListResult, error)
 	GetDhcpStatus(dhcpID string, localVarOptionals map[string]interface{}) (manager.DhcpServerStatus, error)
 }
+
+// TransportNodeClient represents API group Transport Node for NSX-T client.
+type TransportNodeClient interface {
+	ListTransportNodes(localVarOptionals map[string]interface{}) (manager.TransportNodeListResult, error)
+	GetTransportNodeStatus(nodeId string, localVarOptionals map[string]interface{}) (manager.TransportNodeStatus, error)
+}

--- a/client/types.go
+++ b/client/types.go
@@ -18,5 +18,5 @@ type DHCPClient interface {
 // TransportNodeClient represents API group Transport Node for NSX-T client.
 type TransportNodeClient interface {
 	ListTransportNodes(localVarOptionals map[string]interface{}) (manager.TransportNodeListResult, error)
-	GetTransportNodeStatus(nodeId string, localVarOptionals map[string]interface{}) (manager.TransportNodeStatus, error)
+	GetTransportNodeStatus(nodeID string, localVarOptionals map[string]interface{}) (manager.TransportNodeStatus, error)
 }

--- a/client/types.go
+++ b/client/types.go
@@ -18,5 +18,5 @@ type DHCPClient interface {
 // TransportNodeClient represents API group Transport Node for NSX-T client.
 type TransportNodeClient interface {
 	ListTransportNodes(localVarOptionals map[string]interface{}) (manager.TransportNodeListResult, error)
-	GetTransportNodeStatus(nodeID string, localVarOptionals map[string]interface{}) (manager.TransportNodeStatus, error)
+	GetTransportNodeStatus(nodeID string) (manager.TransportNodeStatus, error)
 }

--- a/collector/transport_node_collector.go
+++ b/collector/transport_node_collector.go
@@ -70,7 +70,7 @@ func (c *transportNodeCollector) generateTransportNodeStatusMetrics() (transport
 	}
 
 	for _, transportNode := range transportNodes {
-		transportNodeStatus, err := c.transportNodeClient.GetTransportNodeStatus(transportNode.Id, nil)
+		transportNodeStatus, err := c.transportNodeClient.GetTransportNodeStatus(transportNode.Id)
 		if err != nil {
 			level.Error(c.logger).Log("msg", "Unable to get transport node status", "id", transportNode.Id, "err", err)
 			continue

--- a/collector/transport_node_collector.go
+++ b/collector/transport_node_collector.go
@@ -1,0 +1,88 @@
+package collector
+
+import (
+	"strings"
+
+	"nsxt_exporter/client"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	nsxt "github.com/vmware/go-vmware-nsxt"
+	"github.com/vmware/go-vmware-nsxt/manager"
+)
+
+func init() {
+	registerCollector("transport_node", newTransportNodeCollector)
+}
+
+type transportNodeCollector struct {
+	transportNodeClient client.TransportNodeClient
+	logger              log.Logger
+
+	transportNodeStatus *prometheus.Desc
+}
+
+func newTransportNodeCollector(apiClient *nsxt.APIClient, logger log.Logger) prometheus.Collector {
+	nsxtClient := client.NewNSXTClient(apiClient, logger)
+	transportNodeStatus := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "transport_node", "status"),
+		"Status of Transport Node UP/DOWN",
+		[]string{"id", "name"},
+		nil,
+	)
+	return &transportNodeCollector{
+		transportNodeClient: nsxtClient,
+		logger:              logger,
+		transportNodeStatus: transportNodeStatus,
+	}
+}
+
+// Describe implements the prometheus.Collector interface.
+func (c *transportNodeCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.transportNodeStatus
+}
+
+// Collect implements the prometheus.Collector interface.
+func (c *transportNodeCollector) Collect(ch chan<- prometheus.Metric) {
+	metrics := c.generateTransportNodeStatusMetrics()
+	for _, metric := range metrics {
+		ch <- metric
+	}
+}
+
+func (c *transportNodeCollector) generateTransportNodeStatusMetrics() (transportNodeMetrics []prometheus.Metric) {
+	var transportNodes []manager.TransportNode
+	var cursor string
+	for {
+		localVarOptionals := make(map[string]interface{})
+		localVarOptionals["cursor"] = cursor
+		transportNodesResult, err := c.transportNodeClient.ListTransportNodes(localVarOptionals)
+		if err != nil {
+			level.Error(c.logger).Log("msg", "Unable to list transport nodes", "err", err)
+			return
+		}
+		transportNodes = append(transportNodes, transportNodesResult.Results...)
+		cursor = transportNodesResult.Cursor
+		if len(cursor) == 0 {
+			break
+		}
+	}
+
+	for _, transportNode := range transportNodes {
+		transportNodeStatus, err := c.transportNodeClient.GetTransportNodeStatus(transportNode.Id, nil)
+		if err != nil {
+			level.Error(c.logger).Log("msg", "Unable to get transport node status", "id", transportNode.Id, "err", err)
+			continue
+		}
+		var status float64
+		if strings.ToUpper(transportNodeStatus.Status) == "UP" {
+			status = 1
+		} else {
+			status = 0
+		}
+		transportNodeStatusMetric := prometheus.MustNewConstMetric(c.transportNodeStatus, prometheus.GaugeValue, status, transportNode.Id, transportNode.DisplayName)
+		transportNodeMetrics = append(transportNodeMetrics, transportNodeStatusMetric)
+	}
+	return
+}


### PR DESCRIPTION
This collector will collect metrics for the health state of an individual Transport Nodes. We can monitor a specific Transport Node and find which Transport node is down.

This PR closes #21 

Signed-off-by: William Albertus Dembo <w.albertusd@gmail.com>
