### PR TITLE
Implement system metrics collector

### DIFF
--- a/client/nsxt_client.go
+++ b/client/nsxt_client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"github.com/go-kit/kit/log"
 	nsxt "github.com/vmware/go-vmware-nsxt"
+	"github.com/vmware/go-vmware-nsxt/administration"
 	"github.com/vmware/go-vmware-nsxt/manager"
 )
 
@@ -51,4 +52,19 @@ func (c *nsxtClient) ListTransportNodes(localVarOptionals map[string]interface{}
 func (c *nsxtClient) GetTransportNodeStatus(nodeID string) (manager.TransportNodeStatus, error) {
 	transportNodeStatus, _, err := c.apiClient.TroubleshootingAndMonitoringApi.GetTransportNodeStatus(c.apiClient.Context, nodeID, nil)
 	return transportNodeStatus, err
+}
+
+func (c *nsxtClient) ReadClusterStatus() (administration.ClusterStatus, error) {
+	clusterStatus, _, err := c.apiClient.NsxComponentAdministrationApi.ReadClusterStatus(c.apiClient.Context, nil)
+	return clusterStatus, err
+}
+
+func (c *nsxtClient) ReadClusterNodesAggregateStatus() (administration.ClustersAggregateInfo, error) {
+	clusterNodesStatus, _, err := c.apiClient.NsxComponentAdministrationApi.ReadClusterNodesAggregateStatus(c.apiClient.Context)
+	return clusterNodesStatus, err
+}
+
+func (c *nsxtClient) ReadApplianceManagementServiceStatus() (administration.NodeServiceStatusProperties, error) {
+	applianceServiceStatus, _, err := c.apiClient.NsxComponentAdministrationApi.ReadApplianceManagementServiceStatus(c.apiClient.Context)
+	return applianceServiceStatus, err
 }

--- a/client/types.go
+++ b/client/types.go
@@ -1,6 +1,9 @@
 package client
 
-import "github.com/vmware/go-vmware-nsxt/manager"
+import (
+	"github.com/vmware/go-vmware-nsxt/administration"
+	"github.com/vmware/go-vmware-nsxt/manager"
+)
 
 // LogicalPortClient represents API group logical port for NSX-T client.
 type LogicalPortClient interface {
@@ -19,4 +22,11 @@ type DHCPClient interface {
 type TransportNodeClient interface {
 	ListTransportNodes(localVarOptionals map[string]interface{}) (manager.TransportNodeListResult, error)
 	GetTransportNodeStatus(nodeID string) (manager.TransportNodeStatus, error)
+}
+
+// SystemClient represents API group system for NSX-t client.
+type SystemClient interface {
+	ReadClusterStatus() (administration.ClusterStatus, error)
+	ReadClusterNodesAggregateStatus() (administration.ClustersAggregateInfo, error)
+	ReadApplianceManagementServiceStatus() (administration.NodeServiceStatusProperties, error)
 }

--- a/collector/system_collector.go
+++ b/collector/system_collector.go
@@ -1,0 +1,124 @@
+package collector
+
+import (
+	"nsxt_exporter/client"
+	"strings"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	nsxt "github.com/vmware/go-vmware-nsxt"
+)
+
+func init() {
+	registerCollector("system", newSystemCollector)
+}
+
+type systemCollector struct {
+	systemClient client.SystemClient
+	logger       log.Logger
+
+	clusterStatus                    *prometheus.Desc
+	clusterNodeStatus                *prometheus.Desc
+	applianceManagementServiceStatus *prometheus.Desc
+}
+
+func newSystemCollector(apiClient *nsxt.APIClient, logger log.Logger) prometheus.Collector {
+	nsxtClient := client.NewNSXTClient(apiClient, logger)
+	clusterStatus := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "cluster", "status"),
+		"Status of NSX-T system controller and management cluster.",
+		nil,
+		nil,
+	)
+	clusterNodeStatus := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "cluster_node", "status"),
+		"Status of NSX-T system cluster nodes UP/DOWN.",
+		[]string{"ip_address", "type"},
+		nil,
+	)
+	applianceManagementServiceStatus := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "appliance_service", "status"),
+		"Status of NSX-T appliance management service UP/DOWN.",
+		nil,
+		nil,
+	)
+	return &systemCollector{
+		systemClient: nsxtClient,
+		logger:       logger,
+
+		clusterStatus:                    clusterStatus,
+		clusterNodeStatus:                clusterNodeStatus,
+		applianceManagementServiceStatus: applianceManagementServiceStatus,
+	}
+}
+
+// Describe implements the prometheus.Collector interface.
+func (sc *systemCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- sc.clusterStatus
+	ch <- sc.clusterNodeStatus
+	ch <- sc.applianceManagementServiceStatus
+}
+
+// Collect implements the prometheus.Collector interface.
+func (sc *systemCollector) Collect(ch chan<- prometheus.Metric) {
+	sc.collectClusterStatusMetric(ch)
+	sc.collectClusterNodeMetric(ch)
+	sc.collectClusterServiceMetric(ch)
+}
+
+func (sc *systemCollector) collectClusterStatusMetric(ch chan<- prometheus.Metric) {
+	clusterStatus, err := sc.systemClient.ReadClusterStatus()
+	if err != nil {
+		level.Error(sc.logger).Log("msg", "Unable to collect cluster status")
+		return
+	}
+
+	if strings.ToUpper(clusterStatus.ControlClusterStatus.Status) == "STABLE" &&
+		strings.ToUpper(clusterStatus.MgmtClusterStatus.Status) == "STABLE" {
+		ch <- prometheus.MustNewConstMetric(sc.clusterStatus, prometheus.GaugeValue, 1.0)
+	} else {
+		ch <- prometheus.MustNewConstMetric(sc.clusterStatus, prometheus.GaugeValue, 0.0)
+	}
+}
+
+func (sc *systemCollector) collectClusterNodeMetric(ch chan<- prometheus.Metric) {
+	clusterNodesStatus, err := sc.systemClient.ReadClusterNodesAggregateStatus()
+	if err != nil {
+		level.Error(sc.logger).Log("msg", "Unable to collect cluster nodes status")
+		return
+	}
+
+	for _, c := range clusterNodesStatus.ControllerCluster {
+		ipAddress := c.RoleConfig.ControlPlaneListenAddr.IpAddress
+		if strings.ToUpper(c.NodeStatus.ControlClusterStatus.ControlClusterStatus) == "CONNECTED" &&
+			strings.ToUpper(c.NodeStatus.ControlClusterStatus.MgmtConnectionStatus.ConnectivityStatus) == "CONNECTED" {
+			ch <- prometheus.MustNewConstMetric(sc.clusterNodeStatus, prometheus.GaugeValue, 1.0, ipAddress, "controller")
+		} else {
+			ch <- prometheus.MustNewConstMetric(sc.clusterNodeStatus, prometheus.GaugeValue, 0.0, ipAddress, "controller")
+		}
+	}
+
+	for _, m := range clusterNodesStatus.ManagementCluster {
+		ipAddress := m.RoleConfig.MgmtPlaneListenAddr.IpAddress
+		if strings.ToUpper(m.NodeStatus.MgmtClusterStatus.MgmtClusterStatus) == "CONNECTED" {
+			ch <- prometheus.MustNewConstMetric(sc.clusterNodeStatus, prometheus.GaugeValue, 1.0, ipAddress, "management")
+		} else {
+			ch <- prometheus.MustNewConstMetric(sc.clusterNodeStatus, prometheus.GaugeValue, 0.0, ipAddress, "management")
+		}
+	}
+}
+
+func (sc *systemCollector) collectClusterServiceMetric(ch chan<- prometheus.Metric) {
+	applianceStatus, err := sc.systemClient.ReadApplianceManagementServiceStatus()
+	if err != nil {
+		level.Error(sc.logger).Log("msg", "Unable to collect appliance management service status")
+		return
+	}
+
+	if strings.ToUpper(applianceStatus.RuntimeState) == "RUNNING" {
+		ch <- prometheus.MustNewConstMetric(sc.applianceManagementServiceStatus, prometheus.GaugeValue, 1.0)
+	} else {
+		ch <- prometheus.MustNewConstMetric(sc.applianceManagementServiceStatus, prometheus.GaugeValue, 0.0)
+	}
+}


### PR DESCRIPTION
This collector will collect metrics associated with
NSX-T system health which highly impacted by
controller and manager cluster. In modern NSX-T system, the controller
and manager are included as single appliance cluster. This will
collect 5 metrics: cluster status, cluster node total, cluster node up,
cluster node status, and appliance service.

Signed-off-by: Giri Kuncoro <girikuncoro@gmail.com>