### PR TITLE
Add logical switch collector to collect health status of logical switch

### DIFF
--- a/client/nsxt_client.go
+++ b/client/nsxt_client.go
@@ -78,3 +78,13 @@ func (c *nsxtClient) ReadApplianceManagementServiceStatus() (administration.Node
 	applianceServiceStatus, _, err := c.apiClient.NsxComponentAdministrationApi.ReadApplianceManagementServiceStatus(c.apiClient.Context)
 	return applianceServiceStatus, err
 }
+
+func (c *nsxtClient) ListLogicalSwitches(localVarOptionals map[string]interface{}) (manager.LogicalSwitchListResult, error) {
+	logicalSwitchesResult, _, err := c.apiClient.LogicalSwitchingApi.ListLogicalSwitches(c.apiClient.Context, localVarOptionals)
+	return logicalSwitchesResult, err
+}
+
+func (c *nsxtClient) GetLogicalSwitchState(lswitchID string) (manager.LogicalSwitchState, error) {
+	logicalSwitchesStatus, _, err := c.apiClient.LogicalSwitchingApi.GetLogicalSwitchState(c.apiClient.Context, lswitchID)
+	return logicalSwitchesStatus, err
+}

--- a/client/types.go
+++ b/client/types.go
@@ -9,7 +9,7 @@ import (
 type LogicalPortClient interface {
 	ListLogicalPorts(localVarOptionals map[string]interface{}) (manager.LogicalPortListResult, error)
 	GetLogicalPortStatusSummary(localVarOptionals map[string]interface{}) (manager.LogicalPortStatusSummary, error)
-	GetLogicalPortOperationalStatus(lportId string, localVarOptionals map[string]interface{}) (manager.LogicalPortOperationalStatus, error)
+	GetLogicalPortOperationalStatus(lportID string, localVarOptionals map[string]interface{}) (manager.LogicalPortOperationalStatus, error)
 }
 
 // LogicalRouterPortClient represents API group logical router port for NSX-T client.
@@ -35,4 +35,10 @@ type SystemClient interface {
 	ReadClusterStatus() (administration.ClusterStatus, error)
 	ReadClusterNodesAggregateStatus() (administration.ClustersAggregateInfo, error)
 	ReadApplianceManagementServiceStatus() (administration.NodeServiceStatusProperties, error)
+}
+
+// LogicalSwitchClient represents API group Logical Switch for NSX-T client.
+type LogicalSwitchClient interface {
+	ListLogicalSwitches(localVarOptionals map[string]interface{}) (manager.LogicalSwitchListResult, error)
+	GetLogicalSwitchState(lswitchID string) (manager.LogicalSwitchState, error)
 }

--- a/collector/logical_switch_collector.go
+++ b/collector/logical_switch_collector.go
@@ -1,0 +1,87 @@
+package collector
+
+import (
+	"strings"
+
+	"nsxt_exporter/client"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	nsxt "github.com/vmware/go-vmware-nsxt"
+	"github.com/vmware/go-vmware-nsxt/manager"
+)
+
+func init() {
+	registerCollector("logical_switch", newLogicalSwitchCollector)
+}
+
+type logicalSwitchCollector struct {
+	logicalSwitchClient client.LogicalSwitchClient
+	logger              log.Logger
+
+	logicalSwitchStatus *prometheus.Desc
+}
+
+func newLogicalSwitchCollector(apiClient *nsxt.APIClient, logger log.Logger) prometheus.Collector {
+	nsxtClient := client.NewNSXTClient(apiClient, logger)
+	logicalSwitchStatus := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "logical_switch", "status"),
+		"Status of logical switch success/other",
+		[]string{"id", "name"},
+		nil,
+	)
+	return &logicalSwitchCollector{
+		logicalSwitchClient: nsxtClient,
+		logger:              logger,
+		logicalSwitchStatus: logicalSwitchStatus,
+	}
+}
+
+// Describe implements the prometheus.Collector interface.
+func (c *logicalSwitchCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.logicalSwitchStatus
+}
+
+// Collect implements the prometheus.Collector interface.
+func (c *logicalSwitchCollector) Collect(ch chan<- prometheus.Metric) {
+	metrics := c.generateLogicalSwitchStatusMetrics()
+	for _, metric := range metrics {
+		ch <- metric
+	}
+}
+
+func (c *logicalSwitchCollector) generateLogicalSwitchStatusMetrics() (logicalSwitchMetrics []prometheus.Metric) {
+	var logicalSwitches []manager.LogicalSwitch
+	var cursor string
+	for {
+		localVarOptionals := make(map[string]interface{})
+		localVarOptionals["cursor"] = cursor
+		logicalSwitchsResult, err := c.logicalSwitchClient.ListLogicalSwitches(localVarOptionals)
+		if err != nil {
+			level.Error(c.logger).Log("msg", "Unable to list logical switches", "err", err)
+			return
+		}
+		logicalSwitches = append(logicalSwitches, logicalSwitchsResult.Results...)
+		cursor = logicalSwitchsResult.Cursor
+		if len(cursor) == 0 {
+			break
+		}
+	}
+	for _, logicalSwitch := range logicalSwitches {
+		logicalSwitchStatus, err := c.logicalSwitchClient.GetLogicalSwitchState(logicalSwitch.Id)
+		if err != nil {
+			level.Error(c.logger).Log("msg", "Unable to get logical switch status", "id", logicalSwitch.Id, "err", err)
+			continue
+		}
+		var status float64
+		if strings.ToUpper(logicalSwitchStatus.State) == "SUCCESS" {
+			status = 1
+		} else {
+			status = 0
+		}
+		logicalSwitchStatusMetric := prometheus.MustNewConstMetric(c.logicalSwitchStatus, prometheus.GaugeValue, status, logicalSwitch.Id, logicalSwitch.DisplayName)
+		logicalSwitchMetrics = append(logicalSwitchMetrics, logicalSwitchStatusMetric)
+	}
+	return
+}


### PR DESCRIPTION
This collector will collect metrics for the health state of logical switches. We can monitor a specific logical switch and find which logical switch is not running.

This PR closes #23 

Signed-off-by: William Albertus Dembo <w.albertusd@gmail.com>
