### PR TITLE
Replace client struct with interface for logical router port collector

### DIFF
--- a/client/nsxt_client.go
+++ b/client/nsxt_client.go
@@ -33,6 +33,16 @@ func (c *nsxtClient) GetLogicalPortOperationalStatus(lportId string, localVarOpt
 	return lportStatus, err
 }
 
+func (c *nsxtClient) ListLogicalRouterPorts(localVarOptionals map[string]interface{}) (manager.LogicalRouterPortListResult, error) {
+	lroutersResult, _, err := c.apiClient.LogicalRoutingAndServicesApi.ListLogicalRouterPorts(c.apiClient.Context, localVarOptionals)
+	return lroutersResult, err
+}
+
+func (c *nsxtClient) GetLogicalRouterPortStatisticsSummary(lrportID string) (manager.LogicalRouterPortStatisticsSummary, error) {
+	lrportsStatus, _, err := c.apiClient.LogicalRoutingAndServicesApi.GetLogicalRouterPortStatisticsSummary(c.apiClient.Context, lrportID, nil)
+	return lrportsStatus, err
+}
+
 func (c *nsxtClient) ListDhcpServers(localVarOptionals map[string]interface{}) (manager.LogicalDhcpServerListResult, error) {
 	dhcpServersResult, _, err := c.apiClient.ServicesApi.ListDhcpServers(c.apiClient.Context, localVarOptionals)
 	return dhcpServersResult, err

--- a/client/types.go
+++ b/client/types.go
@@ -9,6 +9,12 @@ type LogicalPortClient interface {
 	GetLogicalPortOperationalStatus(lportId string, localVarOptionals map[string]interface{}) (manager.LogicalPortOperationalStatus, error)
 }
 
+// LogicalRouterPortClient represents API group logical router port for NSX-T client.
+type LogicalRouterPortClient interface {
+	ListLogicalRouterPorts(localVarOptionals map[string]interface{}) (manager.LogicalRouterPortListResult, error)
+	GetLogicalRouterPortStatisticsSummary(lrportID string) (manager.LogicalRouterPortStatisticsSummary, error)
+}
+
 // DHCPClient represents API group DHCP for NSX-T client.
 type DHCPClient interface {
 	ListDhcpServers(localVarOptionals map[string]interface{}) (manager.LogicalDhcpServerListResult, error)


### PR DESCRIPTION
This uses the new interface that makes logical router port
collector more modular so that we can perform testing.

Signed-off-by: Giri Kuncoro <girikuncoro@gmail.com>