### PR TITLE
Differentiate host and edge type of transport nodes

### DIFF
--- a/client/nsxt_client.go
+++ b/client/nsxt_client.go
@@ -64,6 +64,11 @@ func (c *nsxtClient) GetTransportNodeStatus(nodeID string) (manager.TransportNod
 	return transportNodeStatus, err
 }
 
+func (c *nsxtClient) ListEdgeClusters() (manager.EdgeClusterListResult, error) {
+	edgeClustersResult, _, err := c.apiClient.NetworkTransportApi.ListEdgeClusters(c.apiClient.Context, nil)
+	return edgeClustersResult, err
+}
+
 func (c *nsxtClient) ReadClusterStatus() (administration.ClusterStatus, error) {
 	clusterStatus, _, err := c.apiClient.NsxComponentAdministrationApi.ReadClusterStatus(c.apiClient.Context, nil)
 	return clusterStatus, err

--- a/client/nsxt_client.go
+++ b/client/nsxt_client.go
@@ -64,9 +64,23 @@ func (c *nsxtClient) GetTransportNodeStatus(nodeID string) (manager.TransportNod
 	return transportNodeStatus, err
 }
 
-func (c *nsxtClient) ListEdgeClusters() (manager.EdgeClusterListResult, error) {
-	edgeClustersResult, _, err := c.apiClient.NetworkTransportApi.ListEdgeClusters(c.apiClient.Context, nil)
-	return edgeClustersResult, err
+func (c *nsxtClient) ListAllEdgeClusters() ([]manager.EdgeCluster, error) {
+	var edgeClusters []manager.EdgeCluster
+	var cursor string
+	for {
+		localVarOptionals := make(map[string]interface{})
+		localVarOptionals["cursor"] = cursor
+		res, _, err := c.apiClient.NetworkTransportApi.ListEdgeClusters(c.apiClient.Context, localVarOptionals)
+		if err != nil {
+			return nil, err
+		}
+		edgeClusters = append(edgeClusters, res.Results...)
+		cursor = res.Cursor
+		if len(cursor) == 0 {
+			break
+		}
+	}
+	return edgeClusters, nil
 }
 
 func (c *nsxtClient) ReadClusterStatus() (administration.ClusterStatus, error) {

--- a/client/types.go
+++ b/client/types.go
@@ -28,7 +28,7 @@ type DHCPClient interface {
 type TransportNodeClient interface {
 	ListTransportNodes(localVarOptionals map[string]interface{}) (manager.TransportNodeListResult, error)
 	GetTransportNodeStatus(nodeID string) (manager.TransportNodeStatus, error)
-	ListEdgeClusters() (manager.EdgeClusterListResult, error)
+	ListAllEdgeClusters() ([]manager.EdgeCluster, error)
 }
 
 // SystemClient represents API group system for NSX-t client.

--- a/client/types.go
+++ b/client/types.go
@@ -28,6 +28,7 @@ type DHCPClient interface {
 type TransportNodeClient interface {
 	ListTransportNodes(localVarOptionals map[string]interface{}) (manager.TransportNodeListResult, error)
 	GetTransportNodeStatus(nodeID string) (manager.TransportNodeStatus, error)
+	ListEdgeClusters() (manager.EdgeClusterListResult, error)
 }
 
 // SystemClient represents API group system for NSX-t client.

--- a/collector/transport_node_collector.go
+++ b/collector/transport_node_collector.go
@@ -1,7 +1,11 @@
 package collector
 
 import (
+<<<<<<< HEAD
 	"regexp"
+=======
+	"strconv"
+>>>>>>> Differentiate host and edge type of transport nodes
 	"strings"
 
 	"nsxt_exporter/client"
@@ -20,6 +24,7 @@ func init() {
 type transportNodeCollector struct {
 	transportNodeClient client.TransportNodeClient
 	logger              log.Logger
+	edgeClusterMap      map[string]manager.EdgeClusterMember
 
 	transportNodeStatus *prometheus.Desc
 }
@@ -29,7 +34,7 @@ func newTransportNodeCollector(apiClient *nsxt.APIClient, logger log.Logger) pro
 	transportNodeStatus := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "transport_node", "status"),
 		"Status of Transport Node UP/DOWN",
-		[]string{"id", "name"},
+		[]string{"id", "name", "type", "edge_member_index"},
 		nil,
 	)
 	return &transportNodeCollector{
@@ -69,6 +74,7 @@ func (c *transportNodeCollector) generateTransportNodeStatusMetrics() (transport
 		}
 	}
 
+	c.initEdgeClusterMap()
 	for _, transportNode := range transportNodes {
 		transportNodeStatus, err := c.transportNodeClient.GetTransportNodeStatus(transportNode.Id)
 		if err != nil {


### PR DESCRIPTION
NSX transport API provides list of transport nodes which
do not differentiate between host and edge type. Differentiating
this is important, because edge nodes form edge clusters,
which are crucial part of NSX system that stores
stateful services state.

Signed-off-by: Giri Kuncoro <girikuncoro@gmail.com>