### PR TITLE
Remove redundant metrics from logical port collector

### DIFF
--- a/client/nsxt_client.go
+++ b/client/nsxt_client.go
@@ -19,11 +19,6 @@ func NewNSXTClient(apiClient *nsxt.APIClient, logger log.Logger) *nsxtClient {
 	}
 }
 
-func (c *nsxtClient) GetLogicalPortStatusSummary(localVarOptionals map[string]interface{}) (manager.LogicalPortStatusSummary, error) {
-	lportStatus, _, err := c.apiClient.LogicalSwitchingApi.GetLogicalPortStatusSummary(c.apiClient.Context, localVarOptionals)
-	return lportStatus, err
-}
-
 func (c *nsxtClient) ListLogicalPorts(localVarOptionals map[string]interface{}) (manager.LogicalPortListResult, error) {
 	lportsResult, _, err := c.apiClient.LogicalSwitchingApi.ListLogicalPorts(c.apiClient.Context, localVarOptionals)
 	return lportsResult, err

--- a/client/types.go
+++ b/client/types.go
@@ -8,7 +8,6 @@ import (
 // LogicalPortClient represents API group logical port for NSX-T client.
 type LogicalPortClient interface {
 	ListLogicalPorts(localVarOptionals map[string]interface{}) (manager.LogicalPortListResult, error)
-	GetLogicalPortStatusSummary(localVarOptionals map[string]interface{}) (manager.LogicalPortStatusSummary, error)
 	GetLogicalPortOperationalStatus(lportID string, localVarOptionals map[string]interface{}) (manager.LogicalPortOperationalStatus, error)
 }
 


### PR DESCRIPTION
Total logical port and total up port are redundant because its value can be derived from logical port status metric.

Signed-off-by: William Albertus Dembo <w.albertusd@gmail.com>