### PR TITLE
Add test to dhcp_collector and refactor

### DIFF
--- a/.github/workflows/master-workflow.yaml
+++ b/.github/workflows/master-workflow.yaml
@@ -17,6 +17,8 @@ jobs:
       uses: actions/checkout@v1
     - name: Build golang binary
       run: make build
+    - name: Running code tests
+      run: make test
     - name: Logging in to container registry
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -1,0 +1,21 @@
+name: Pull Request
+on:
+  pull_request:
+    branches:
+    - master
+jobs:
+    test:
+        name: Test
+        runs-on: ubuntu-latest
+        steps:
+        - name: Set up Go 1.13
+          uses: actions/setup-go@v1
+          with:
+            go-version: 1.13
+          id: go
+        - name: Check out code into the Go module directory
+          uses: actions/checkout@v1
+        - name: Build golang binary
+          run: make build
+        - name: Running code tests
+          run: make test

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ ENVVAR=CGO_ENABLED=0 GO111MODULE=on
 PKGS=./...
 
 GO?=go
+GOTEST?=$(GO) test
 GOFMT?=$(GO) fmt
 GOOS?=$(shell $(GO) env GOHOSTOS)
 GOARCH?=$(shell $(GO) env GOHOSTARCH)
@@ -27,6 +28,10 @@ endif
 build:
 	mkdir -p .build/${GOOS}-${GOARCH}
 	$(ENVVAR) GOOS=$(GOOS) go build -o .build/${GOOS}-${GOARCH}/nsxt_exporter ${LDFLAGS_FLAG}
+
+.PHONY: test
+test:
+	$(GOTEST) $(PKGS)
 
 .PHONY: fmt
 fmt:

--- a/collector/dhcp_collector_test.go
+++ b/collector/dhcp_collector_test.go
@@ -1,0 +1,153 @@
+package collector
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/go-vmware-nsxt/manager"
+)
+
+const (
+	fakeDHCPServerID          = "fake-dhcp-server-id"
+	fakeDHCPServerDisplayName = "fake-dhcp-server-name"
+)
+
+type mockDHCPClient struct {
+	responses     []mockDHCPResponse
+	dhcpListError error
+}
+
+type mockDHCPResponse struct {
+	ID          string
+	DisplayName string
+	Status      string
+	Error       error
+}
+
+func (c *mockDHCPClient) ListDhcpServers(localVarOptionals map[string]interface{}) (manager.LogicalDhcpServerListResult, error) {
+	if c.dhcpListError != nil {
+		return manager.LogicalDhcpServerListResult{}, c.dhcpListError
+	}
+	var dhcpServers []manager.LogicalDhcpServer
+	for _, response := range c.responses {
+		dhcpServer := manager.LogicalDhcpServer{
+			Id:          response.ID,
+			DisplayName: response.DisplayName,
+		}
+		dhcpServers = append(dhcpServers, dhcpServer)
+	}
+	return manager.LogicalDhcpServerListResult{
+		Results: dhcpServers,
+	}, nil
+}
+
+func (c *mockDHCPClient) GetDhcpStatus(dhcpID string, localVarOptionals map[string]interface{}) (manager.DhcpServerStatus, error) {
+	for _, res := range c.responses {
+		if res.ID == dhcpID {
+			return manager.DhcpServerStatus{
+				ServiceStatus: res.Status,
+			}, res.Error
+		}
+	}
+	return manager.DhcpServerStatus{}, errors.New("error")
+}
+
+func buildDHCPResponse(id string, status string, err error) mockDHCPResponse {
+	return mockDHCPResponse{
+		ID:          fakeDHCPServerID + "-" + id,
+		DisplayName: fakeDHCPServerDisplayName + "-" + id,
+		Status:      status,
+		Error:       err,
+	}
+}
+
+func TestDHCPCollector_GenerateDHCPStatusMetrics(t *testing.T) {
+	testcases := []struct {
+		dhcpListError   error
+		dhcpResponses   []mockDHCPResponse
+		expectedMetrics []dhcpStatusMetric
+	}{
+		{
+			dhcpListError: nil,
+			dhcpResponses: []mockDHCPResponse{
+				buildDHCPResponse("01", "UP", nil),
+				buildDHCPResponse("02", "DOWN", nil),
+				buildDHCPResponse("03", "ERROR", nil),
+				buildDHCPResponse("04", "NO_STANDBY", nil),
+				buildDHCPResponse("05", "Up", nil),
+				buildDHCPResponse("06", "dOwN", nil),
+			},
+			expectedMetrics: []dhcpStatusMetric{
+				{
+					ID:     "fake-dhcp-server-id-01",
+					Name:   "fake-dhcp-server-name-01",
+					Status: 1.0,
+				},
+				{
+					ID:     "fake-dhcp-server-id-02",
+					Name:   "fake-dhcp-server-name-02",
+					Status: 0.0,
+				},
+				{
+					ID:     "fake-dhcp-server-id-03",
+					Name:   "fake-dhcp-server-name-03",
+					Status: 0.0,
+				},
+				{
+					ID:     "fake-dhcp-server-id-04",
+					Name:   "fake-dhcp-server-name-04",
+					Status: 0.0,
+				},
+				{
+					ID:     "fake-dhcp-server-id-05",
+					Name:   "fake-dhcp-server-name-05",
+					Status: 1.0,
+				},
+				{
+					ID:     "fake-dhcp-server-id-06",
+					Name:   "fake-dhcp-server-name-06",
+					Status: 0.0,
+				},
+			},
+		},
+		{
+			dhcpListError: nil,
+			dhcpResponses: []mockDHCPResponse{
+				buildDHCPResponse("01", "UP", nil),
+				buildDHCPResponse("02", "UP", errors.New("error get dhcp")),
+			},
+			expectedMetrics: []dhcpStatusMetric{
+				{
+					ID:     "fake-dhcp-server-id-01",
+					Name:   "fake-dhcp-server-name-01",
+					Status: 1.0,
+				},
+			},
+		},
+		{
+			dhcpListError: errors.New("error list dhcp"),
+			dhcpResponses: []mockDHCPResponse{
+				buildDHCPResponse("01", "UP", nil),
+				buildDHCPResponse("02", "UP", nil),
+			},
+			expectedMetrics: []dhcpStatusMetric{},
+		},
+		{
+			dhcpListError:   nil,
+			dhcpResponses:   []mockDHCPResponse{},
+			expectedMetrics: []dhcpStatusMetric{},
+		},
+	}
+	for _, tc := range testcases {
+		mockDHCPClient := &mockDHCPClient{
+			dhcpListError: tc.dhcpListError,
+			responses:     tc.dhcpResponses,
+		}
+		logger := log.NewNopLogger()
+		dhcpCollector := newDHCPCollector(mockDHCPClient, logger)
+		dhcpMetrics := dhcpCollector.generateDHCPStatusMetrics()
+		assert.ElementsMatch(t, tc.expectedMetrics, dhcpMetrics)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/prometheus/client_golang v1.0.0
 	github.com/prometheus/common v0.9.1
-	github.com/stretchr/testify v1.4.0 // indirect
+	github.com/stretchr/testify v1.4.0
 	github.com/vmware/go-vmware-nsxt v0.0.0-20200114231430-33a5af043f2e
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 // indirect
 	golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7 // indirect


### PR DESCRIPTION
This refactors dchp collector to be easier to test:
* Wrap constructor that can pass interface
* Change signature of metrics generator to not return prometheus.Metric
* Add tests for dhcp_collector

Signed-off-by: Giri Kuncoro <girikuncoro@gmail.com>
Co-authored-by: William Albertus Dembo <w.albertusd@gmail.com>