### PR TITLE
Transport node collector test and refactor

### DIFF
--- a/client/nsxt_client.go
+++ b/client/nsxt_client.go
@@ -49,9 +49,23 @@ func (c *nsxtClient) GetDhcpStatus(dhcpID string, localVarOptionals map[string]i
 	return dhcpServerStatus, err
 }
 
-func (c *nsxtClient) ListTransportNodes(localVarOptionals map[string]interface{}) (manager.TransportNodeListResult, error) {
-	transportNodeStatus, _, err := c.apiClient.NetworkTransportApi.ListTransportNodes(c.apiClient.Context, localVarOptionals)
-	return transportNodeStatus, err
+func (c *nsxtClient) ListAllTransportNodes() ([]manager.TransportNode, error) {
+	var transportNodes []manager.TransportNode
+	var cursor string
+	for {
+		localVarOptionals := make(map[string]interface{})
+		localVarOptionals["cursor"] = cursor
+		transportNodesResult, _, err := c.apiClient.NetworkTransportApi.ListTransportNodes(c.apiClient.Context, localVarOptionals)
+		if err != nil {
+			return nil, err
+		}
+		transportNodes = append(transportNodes, transportNodesResult.Results...)
+		cursor = transportNodesResult.Cursor
+		if len(cursor) == 0 {
+			break
+		}
+	}
+	return transportNodes, nil
 }
 
 func (c *nsxtClient) GetTransportNodeStatus(nodeID string) (manager.TransportNodeStatus, error) {

--- a/client/types.go
+++ b/client/types.go
@@ -25,7 +25,7 @@ type DHCPClient interface {
 
 // TransportNodeClient represents API group Transport Node for NSX-T client.
 type TransportNodeClient interface {
-	ListTransportNodes(localVarOptionals map[string]interface{}) (manager.TransportNodeListResult, error)
+	ListAllTransportNodes() ([]manager.TransportNode, error)
 	GetTransportNodeStatus(nodeID string) (manager.TransportNodeStatus, error)
 	ListAllEdgeClusters() ([]manager.EdgeCluster, error)
 }

--- a/collector/transport_node_collector.go
+++ b/collector/transport_node_collector.go
@@ -15,7 +15,7 @@ import (
 )
 
 func init() {
-	registerCollector("transport_node", newTransportNodeCollector)
+	registerCollector("transport_node", createTransportNodeCollectorFactory)
 }
 
 type edgeClusterMembership struct {
@@ -31,8 +31,12 @@ type transportNodeCollector struct {
 	edgeClusterMembership *prometheus.Desc
 }
 
-func newTransportNodeCollector(apiClient *nsxt.APIClient, logger log.Logger) prometheus.Collector {
+func createTransportNodeCollectorFactory(apiClient *nsxt.APIClient, logger log.Logger) prometheus.Collector {
 	nsxtClient := client.NewNSXTClient(apiClient, logger)
+	return newTransportNodeCollector(nsxtClient, logger)
+}
+
+func newTransportNodeCollector(transportNodeClient client.TransportNodeClient, logger log.Logger) *transportNodeCollector {
 	edgeClusterMembership := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "transport_node", "edge_cluster_membership"),
 		"Membership info of Transport Node in an Edge Cluster",
@@ -40,7 +44,7 @@ func newTransportNodeCollector(apiClient *nsxt.APIClient, logger log.Logger) pro
 		nil,
 	)
 	return &transportNodeCollector{
-		transportNodeClient:   nsxtClient,
+		transportNodeClient:   transportNodeClient,
 		logger:                logger,
 		edgeClusterMembership: edgeClusterMembership,
 	}

--- a/collector/transport_node_collector.go
+++ b/collector/transport_node_collector.go
@@ -55,6 +55,7 @@ func (c *transportNodeCollector) Describe(ch chan<- *prometheus.Desc) {
 func (c *transportNodeCollector) Collect(ch chan<- prometheus.Metric) {
 	edgeClusterMemberships, err := c.generateEdgeClusterMemberships()
 	if err != nil {
+		edgeClusterMemberships = nil
 		level.Error(c.logger).Log("msg", "Unable to generate edge cluster membership", "err", err)
 	}
 	for _, membership := range edgeClusterMemberships {
@@ -97,8 +98,10 @@ func (c *transportNodeCollector) generateTransportNodeMetrics(edgeClusterMembers
 			status = 0
 		}
 
-		// TODO, when generateEdgeClusterMemberships is failed, should not fill type
-		transportNodeType := "host"
+		var transportNodeType string
+		if edgeClusterMemberships != nil {
+			transportNodeType = "host"
+		}
 		for _, membership := range edgeClusterMemberships {
 			if membership.transportNodeID == transportNode.Id {
 				transportNodeType = "edge"

--- a/collector/transport_node_collector.go
+++ b/collector/transport_node_collector.go
@@ -59,23 +59,11 @@ func (c *transportNodeCollector) Collect(ch chan<- prometheus.Metric) {
 }
 
 func (c *transportNodeCollector) generateTransportNodeMetrics() (transportNodeMetrics []prometheus.Metric) {
-	var transportNodes []manager.TransportNode
-	var cursor string
-	for {
-		localVarOptionals := make(map[string]interface{})
-		localVarOptionals["cursor"] = cursor
-		transportNodesResult, err := c.transportNodeClient.ListTransportNodes(localVarOptionals)
-		if err != nil {
-			level.Error(c.logger).Log("msg", "Unable to list transport nodes", "err", err)
-			return
-		}
-		transportNodes = append(transportNodes, transportNodesResult.Results...)
-		cursor = transportNodesResult.Cursor
-		if len(cursor) == 0 {
-			break
-		}
+	transportNodes, err := c.transportNodeClient.ListAllTransportNodes()
+	if err != nil {
+		level.Error(c.logger).Log("msg", "Unable to list transport nodes", "err", err)
+		return
 	}
-
 	edgeClusterMap, err := c.initEdgeClusterMap()
 	if err != nil {
 		level.Error(c.logger).Log("msg", "Unable to initalize edge cluster map", "err", err)

--- a/collector/transport_node_collector_test.go
+++ b/collector/transport_node_collector_test.go
@@ -1,0 +1,108 @@
+package collector
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/go-vmware-nsxt/manager"
+)
+
+type transportNodeClientMock struct {
+	edgeClustersResponse []manager.EdgeCluster
+	edgeClustersError    error
+}
+
+func (c *transportNodeClientMock) ListAllTransportNodes() ([]manager.TransportNode, error) {
+	panic("implement me")
+}
+
+func (c *transportNodeClientMock) GetTransportNodeStatus(nodeID string) (manager.TransportNodeStatus, error) {
+	panic("implement me")
+}
+
+func (c *transportNodeClientMock) ListAllEdgeClusters() ([]manager.EdgeCluster, error) {
+	return c.edgeClustersResponse, c.edgeClustersError
+}
+
+func TestTransportNodeCollector_GenerateEdgeClusterMemberships(t *testing.T) {
+	testcases := []struct {
+		description          string
+		edgeClustersResponse []manager.EdgeCluster
+		edgeClustersError    error
+		expectedMembership   []edgeClusterMembership
+		expectingError       bool
+	}{
+		{
+			description: "Should return correct edge cluster memberships",
+			edgeClustersResponse: []manager.EdgeCluster{
+				{
+					Id: "fake-edge-cluster-id-01",
+					Members: []manager.EdgeClusterMember{
+						{
+							TransportNodeId: "fake-transport-node-id-01",
+							MemberIndex:     0,
+						}, {
+							TransportNodeId: "fake-transport-node-id-02",
+							MemberIndex:     1,
+						},
+					},
+				}, {
+					Id: "fake-edge-cluster-id-02",
+					Members: []manager.EdgeClusterMember{
+						{
+							TransportNodeId: "fake-transport-node-id-01",
+							MemberIndex:     0,
+						},
+					},
+				}, {
+					Id:      "fake-edge-cluster-id-03",
+					Members: []manager.EdgeClusterMember{},
+				},
+			},
+			edgeClustersError: nil,
+			expectedMembership: []edgeClusterMembership{
+				{
+					edgeClusterID:   "fake-edge-cluster-id-01",
+					transportNodeID: "fake-transport-node-id-01",
+					edgeMemberIndex: "0",
+				}, {
+					edgeClusterID:   "fake-edge-cluster-id-01",
+					transportNodeID: "fake-transport-node-id-02",
+					edgeMemberIndex: "1",
+				}, {
+					edgeClusterID:   "fake-edge-cluster-id-02",
+					transportNodeID: "fake-transport-node-id-01",
+					edgeMemberIndex: "0",
+				},
+			},
+			expectingError: false,
+		}, {
+			description:          "Should return empty memberships when got no edge cluster",
+			edgeClustersResponse: []manager.EdgeCluster{},
+			edgeClustersError:    nil,
+			expectedMembership:   []edgeClusterMembership{},
+			expectingError:       false,
+		}, {
+			description:          "Should error when failed to list edge cluster",
+			edgeClustersResponse: []manager.EdgeCluster{},
+			edgeClustersError:    errors.New("failed to list edge cluster"),
+			expectedMembership:   nil,
+			expectingError:       true,
+		},
+	}
+	for _, tc := range testcases {
+		client := &transportNodeClientMock{
+			edgeClustersResponse: tc.edgeClustersResponse,
+			edgeClustersError:    tc.edgeClustersError,
+		}
+		logger := log.NewNopLogger()
+		collector := newTransportNodeCollector(client, logger)
+		memberships, err := collector.generateEdgeClusterMemberships()
+		if tc.expectingError {
+			assert.Error(t, err, tc.description)
+		}
+		assert.ElementsMatch(t, memberships, tc.expectedMembership, tc.description)
+	}
+}


### PR DESCRIPTION
Add test for transport node collector and refactors to help build the test:

 - Wrap constructor that can pass client interface
 - Abstract list all transport node to the client
 - Separate metrics for transport node status and transport node membership
 - Change the signature method to generate edge cluster membership

Address: #36 

Signed-off-by: William Albertus Dembo w.albertusd@gmail.com

