### PR TITLE
Add logical switch statistics metrics and refactor

### DIFF
--- a/client/nsxt_client.go
+++ b/client/nsxt_client.go
@@ -121,9 +121,23 @@ func (c *nsxtClient) ReadApplianceManagementServiceStatus() (administration.Node
 	return applianceServiceStatus, err
 }
 
-func (c *nsxtClient) ListLogicalSwitches(localVarOptionals map[string]interface{}) (manager.LogicalSwitchListResult, error) {
-	logicalSwitchesResult, _, err := c.apiClient.LogicalSwitchingApi.ListLogicalSwitches(c.apiClient.Context, localVarOptionals)
-	return logicalSwitchesResult, err
+func (c *nsxtClient) ListAllLogicalSwitches() ([]manager.LogicalSwitch, error) {
+	var logicalSwitches []manager.LogicalSwitch
+	var cursor string
+	for {
+		localVarOptionals := make(map[string]interface{})
+		localVarOptionals["cursor"] = cursor
+		logicalSwitchListResult, _, err := c.apiClient.LogicalSwitchingApi.ListLogicalSwitches(c.apiClient.Context, localVarOptionals)
+		if err != nil {
+			return nil, err
+		}
+		logicalSwitches = append(logicalSwitches, logicalSwitchListResult.Results...)
+		cursor = logicalSwitchListResult.Cursor
+		if len(cursor) == 0 {
+			break
+		}
+	}
+	return logicalSwitches, nil
 }
 
 func (c *nsxtClient) GetLogicalSwitchState(lswitchID string) (manager.LogicalSwitchState, error) {

--- a/client/nsxt_client.go
+++ b/client/nsxt_client.go
@@ -144,3 +144,8 @@ func (c *nsxtClient) GetLogicalSwitchState(lswitchID string) (manager.LogicalSwi
 	logicalSwitchesStatus, _, err := c.apiClient.LogicalSwitchingApi.GetLogicalSwitchState(c.apiClient.Context, lswitchID)
 	return logicalSwitchesStatus, err
 }
+
+func (c *nsxtClient) GetLogicalSwitchStatistic(lswitchID string) (manager.LogicalSwitchStatistics, error) {
+	logicalSwitchStatistic, _, err := c.apiClient.LogicalSwitchingApi.GetLogicalSwitchStatistics(c.apiClient.Context, lswitchID, nil)
+	return logicalSwitchStatistic, err
+}

--- a/client/types.go
+++ b/client/types.go
@@ -41,4 +41,5 @@ type SystemClient interface {
 type LogicalSwitchClient interface {
 	ListAllLogicalSwitches() ([]manager.LogicalSwitch, error)
 	GetLogicalSwitchState(lswitchID string) (manager.LogicalSwitchState, error)
+	GetLogicalSwitchStatistic(lswitchID string) (manager.LogicalSwitchStatistics, error)
 }

--- a/client/types.go
+++ b/client/types.go
@@ -39,6 +39,6 @@ type SystemClient interface {
 
 // LogicalSwitchClient represents API group Logical Switch for NSX-T client.
 type LogicalSwitchClient interface {
-	ListLogicalSwitches(localVarOptionals map[string]interface{}) (manager.LogicalSwitchListResult, error)
+	ListAllLogicalSwitches() ([]manager.LogicalSwitch, error)
 	GetLogicalSwitchState(lswitchID string) (manager.LogicalSwitchState, error)
 }

--- a/collector/logical_switch_collector.go
+++ b/collector/logical_switch_collector.go
@@ -21,6 +21,14 @@ type logicalSwitchCollector struct {
 	logger              log.Logger
 
 	logicalSwitchStatus *prometheus.Desc
+	rxByteTotal         *prometheus.Desc
+	rxByteDropped       *prometheus.Desc
+	rxPacketTotal       *prometheus.Desc
+	rxPacketDropped     *prometheus.Desc
+	txByteTotal         *prometheus.Desc
+	txByteDropped       *prometheus.Desc
+	txPacketTotal       *prometheus.Desc
+	txPacketDropped     *prometheus.Desc
 }
 
 type logicalSwitchStatusMetric struct {
@@ -28,6 +36,20 @@ type logicalSwitchStatusMetric struct {
 	Name            string
 	TransportZoneID string
 	Status          float64
+}
+
+type logicalSwitchStatisticMetric struct {
+	ID              string
+	Name            string
+	TransportZoneID string
+	RxByteTotal     float64
+	RxByteDropped   float64
+	RxPacketTotal   float64
+	RxPacketDropped float64
+	TxByteTotal     float64
+	TxByteDropped   float64
+	TxPacketTotal   float64
+	TxPacketDropped float64
 }
 
 func createLogicalSwitchFactory(apiClient *nsxt.APIClient, logger log.Logger) prometheus.Collector {
@@ -42,16 +64,80 @@ func newLogicalSwitchCollector(lswitchClient client.LogicalSwitchClient, logger 
 		[]string{"id", "name", "transport_zone_id"},
 		nil,
 	)
+	rxByteTotal := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "logical_switch", "rx_byte"),
+		"Total bytes received (rx) on logical switch",
+		[]string{"id", "name", "transport_zone_id"},
+		nil,
+	)
+	rxByteDropped := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "logical_switch", "rx_dropped_byte"),
+		"Total receive (rx) bytes dropped on logical switch",
+		[]string{"id", "name", "transport_zone_id"},
+		nil,
+	)
+	rxPacketTotal := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "logical_switch", "rx_packet"),
+		"Total packets received (rx) on logical switch",
+		[]string{"id", "name", "transport_zone_id"},
+		nil,
+	)
+	rxPacketDropped := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "logical_switch", "rx_dropped_packet"),
+		"Total receive (rx) packets dropped on logical switch",
+		[]string{"id", "name", "transport_zone_id"},
+		nil,
+	)
+	txByteTotal := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "logical_switch", "tx_byte"),
+		"Total bytes transmitted (tx) on logical switch",
+		[]string{"id", "name", "transport_zone_id"},
+		nil,
+	)
+	txByteDropped := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "logical_switch", "tx_dropped_byte"),
+		"Total transmit (tx) bytes dropped on logical switch",
+		[]string{"id", "name", "transport_zone_id"},
+		nil,
+	)
+	txPacketTotal := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "logical_switch", "tx_packet"),
+		"Total packets transmitted (tx) on logical switch",
+		[]string{"id", "name", "transport_zone_id"},
+		nil,
+	)
+	txPacketDropped := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "logical_switch", "tx_dropped_packet"),
+		"Total transmit (tx) packets dropped on logical switch",
+		[]string{"id", "name", "transport_zone_id"},
+		nil,
+	)
 	return &logicalSwitchCollector{
 		logicalSwitchClient: lswitchClient,
 		logger:              logger,
 		logicalSwitchStatus: logicalSwitchStatus,
+		rxPacketTotal:       rxPacketTotal,
+		rxPacketDropped:     rxPacketDropped,
+		rxByteTotal:         rxByteTotal,
+		rxByteDropped:       rxByteDropped,
+		txPacketTotal:       txPacketTotal,
+		txPacketDropped:     txPacketDropped,
+		txByteTotal:         txByteTotal,
+		txByteDropped:       txByteDropped,
 	}
 }
 
 // Describe implements the prometheus.Collector interface.
 func (c *logicalSwitchCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.logicalSwitchStatus
+	ch <- c.rxByteTotal
+	ch <- c.rxByteDropped
+	ch <- c.rxPacketTotal
+	ch <- c.rxPacketDropped
+	ch <- c.txByteTotal
+	ch <- c.txByteDropped
+	ch <- c.txPacketTotal
+	ch <- c.txPacketDropped
 }
 
 // Collect implements the prometheus.Collector interface.
@@ -65,6 +151,18 @@ func (c *logicalSwitchCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, m := range lswitchStatusMetrics {
 		labels := []string{m.ID, m.Name, m.TransportZoneID}
 		ch <- prometheus.MustNewConstMetric(c.logicalSwitchStatus, prometheus.GaugeValue, m.Status, labels...)
+	}
+	lswitchStatisticMetrics := c.generateLogicalSwitchStatisticMetrics(logicalSwitches)
+	for _, metric := range lswitchStatisticMetrics {
+		labels := []string{metric.ID, metric.Name, metric.TransportZoneID}
+		ch <- prometheus.MustNewConstMetric(c.rxByteTotal, prometheus.GaugeValue, metric.RxByteTotal, labels...)
+		ch <- prometheus.MustNewConstMetric(c.rxByteDropped, prometheus.GaugeValue, metric.RxByteDropped, labels...)
+		ch <- prometheus.MustNewConstMetric(c.rxPacketTotal, prometheus.GaugeValue, metric.RxPacketTotal, labels...)
+		ch <- prometheus.MustNewConstMetric(c.rxPacketDropped, prometheus.GaugeValue, metric.RxPacketDropped, labels...)
+		ch <- prometheus.MustNewConstMetric(c.txByteTotal, prometheus.GaugeValue, metric.TxByteTotal, labels...)
+		ch <- prometheus.MustNewConstMetric(c.txByteDropped, prometheus.GaugeValue, metric.TxByteDropped, labels...)
+		ch <- prometheus.MustNewConstMetric(c.txPacketTotal, prometheus.GaugeValue, metric.TxPacketTotal, labels...)
+		ch <- prometheus.MustNewConstMetric(c.txPacketDropped, prometheus.GaugeValue, metric.TxPacketDropped, labels...)
 	}
 }
 
@@ -88,6 +186,31 @@ func (c *logicalSwitchCollector) generateLogicalSwitchStatusMetrics(logicalSwitc
 			Status:          status,
 		}
 		logicalSwitchStatusMetrics = append(logicalSwitchStatusMetrics, logicalSwitchStatusMetric)
+	}
+	return
+}
+
+func (c *logicalSwitchCollector) generateLogicalSwitchStatisticMetrics(logicalSwitches []manager.LogicalSwitch) (logicalSwitchStatisticMetrics []logicalSwitchStatisticMetric) {
+	for _, logicalSwitch := range logicalSwitches {
+		logicalSwitchStatistic, err := c.logicalSwitchClient.GetLogicalSwitchStatistic(logicalSwitch.Id)
+		if err != nil {
+			level.Error(c.logger).Log("msg", "Unable to get logical switch statistic", "id", logicalSwitch.Id, "err", err)
+			continue
+		}
+		logicalSwitchStatisticMetric := logicalSwitchStatisticMetric{
+			ID:              logicalSwitch.Id,
+			Name:            logicalSwitch.DisplayName,
+			TransportZoneID: logicalSwitch.TransportZoneId,
+			RxByteTotal:     float64(logicalSwitchStatistic.RxBytes.Total),
+			RxByteDropped:   float64(logicalSwitchStatistic.RxBytes.Dropped),
+			RxPacketTotal:   float64(logicalSwitchStatistic.RxPackets.Total),
+			RxPacketDropped: float64(logicalSwitchStatistic.RxPackets.Dropped),
+			TxByteTotal:     float64(logicalSwitchStatistic.TxBytes.Total),
+			TxByteDropped:   float64(logicalSwitchStatistic.TxBytes.Dropped),
+			TxPacketTotal:   float64(logicalSwitchStatistic.TxPackets.Total),
+			TxPacketDropped: float64(logicalSwitchStatistic.TxPackets.Dropped),
+		}
+		logicalSwitchStatisticMetrics = append(logicalSwitchStatisticMetrics, logicalSwitchStatisticMetric)
 	}
 	return
 }

--- a/collector/logical_switch_collector.go
+++ b/collector/logical_switch_collector.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	nsxt "github.com/vmware/go-vmware-nsxt"
-	"github.com/vmware/go-vmware-nsxt/manager"
 )
 
 func init() {
@@ -64,21 +63,10 @@ func (c *logicalSwitchCollector) Collect(ch chan<- prometheus.Metric) {
 }
 
 func (c *logicalSwitchCollector) generateLogicalSwitchStatusMetrics() (logicalSwitchStatusMetrics []logicalSwitchStatusMetric) {
-	var logicalSwitches []manager.LogicalSwitch
-	var cursor string
-	for {
-		localVarOptionals := make(map[string]interface{})
-		localVarOptionals["cursor"] = cursor
-		logicalSwitchsResult, err := c.logicalSwitchClient.ListLogicalSwitches(localVarOptionals)
-		if err != nil {
-			level.Error(c.logger).Log("msg", "Unable to list logical switches", "err", err)
-			return
-		}
-		logicalSwitches = append(logicalSwitches, logicalSwitchsResult.Results...)
-		cursor = logicalSwitchsResult.Cursor
-		if len(cursor) == 0 {
-			break
-		}
+	logicalSwitches, err := c.logicalSwitchClient.ListAllLogicalSwitches()
+	if err != nil {
+		level.Error(c.logger).Log("msg", "Unable to list logical switches", "err", err)
+		return
 	}
 	for _, logicalSwitch := range logicalSwitches {
 		logicalSwitchStatus, err := c.logicalSwitchClient.GetLogicalSwitchState(logicalSwitch.Id)

--- a/collector/logical_switch_collector_test.go
+++ b/collector/logical_switch_collector_test.go
@@ -21,11 +21,9 @@ type mockLogicalSwitchClient struct {
 }
 
 type mockLogicalSwitchResponse struct {
-	ID              string
-	DisplayName     string
-	TransportZoneId string
-	Status          string
-	Error           error
+	logicalSwitch manager.LogicalSwitch
+	Status        string
+	Error         error
 }
 
 func (c *mockLogicalSwitchClient) ListAllLogicalSwitches() ([]manager.LogicalSwitch, error) {
@@ -34,19 +32,14 @@ func (c *mockLogicalSwitchClient) ListAllLogicalSwitches() ([]manager.LogicalSwi
 	}
 	var lswitches []manager.LogicalSwitch
 	for _, res := range c.responses {
-		lswitch := manager.LogicalSwitch{
-			Id:              res.ID,
-			DisplayName:     res.DisplayName,
-			TransportZoneId: res.TransportZoneId,
-		}
-		lswitches = append(lswitches, lswitch)
+		lswitches = append(lswitches, res.logicalSwitch)
 	}
 	return lswitches, nil
 }
 
 func (c *mockLogicalSwitchClient) GetLogicalSwitchState(lswitchID string) (manager.LogicalSwitchState, error) {
 	for _, res := range c.responses {
-		if res.ID == lswitchID {
+		if res.logicalSwitch.Id == lswitchID {
 			return manager.LogicalSwitchState{
 				State: res.Status,
 			}, res.Error
@@ -57,11 +50,13 @@ func (c *mockLogicalSwitchClient) GetLogicalSwitchState(lswitchID string) (manag
 
 func buildLogicalSwitchResponse(id string, status string, err error) mockLogicalSwitchResponse {
 	return mockLogicalSwitchResponse{
-		ID:              fakeLogicalSwitchID + "-" + id,
-		DisplayName:     fakeLogicalSwitchDisplayName + "-" + id,
-		TransportZoneId: fakeLogicalSwitchTransportZoneID + "-" + id,
-		Status:          status,
-		Error:           err,
+		logicalSwitch: manager.LogicalSwitch{
+			Id:              fakeLogicalSwitchID + "-" + id,
+			DisplayName:     fakeLogicalSwitchDisplayName + "-" + id,
+			TransportZoneId: fakeLogicalSwitchTransportZoneID + "-" + id,
+		},
+		Status: status,
+		Error:  err,
 	}
 }
 

--- a/collector/logical_switch_collector_test.go
+++ b/collector/logical_switch_collector_test.go
@@ -20,9 +20,10 @@ type mockLogicalSwitchClient struct {
 }
 
 type mockLogicalSwitchResponse struct {
-	logicalSwitch manager.LogicalSwitch
-	Status        string
-	Error         error
+	logicalSwitch  manager.LogicalSwitch
+	Status         string
+	StatisticValue int64
+	Error          error
 }
 
 func (c *mockLogicalSwitchClient) ListAllLogicalSwitches() ([]manager.LogicalSwitch, error) {
@@ -40,7 +41,25 @@ func (c *mockLogicalSwitchClient) GetLogicalSwitchState(lswitchID string) (manag
 	return manager.LogicalSwitchState{}, errors.New("error")
 }
 
-func buildLogicalSwitchResponse(id string, status string, err error) mockLogicalSwitchResponse {
+func (c *mockLogicalSwitchClient) GetLogicalSwitchStatistic(lswitchID string) (manager.LogicalSwitchStatistics, error) {
+	for _, res := range c.responses {
+		if res.logicalSwitch.Id == lswitchID {
+			dataCounter := &manager.DataCounter{
+				Total:   res.StatisticValue,
+				Dropped: res.StatisticValue,
+			}
+			return manager.LogicalSwitchStatistics{
+				RxPackets: dataCounter,
+				RxBytes:   dataCounter,
+				TxPackets: dataCounter,
+				TxBytes:   dataCounter,
+			}, res.Error
+		}
+	}
+	panic("implement me")
+}
+
+func buildLogicalSwitchStatusResponse(id string, status string, err error) mockLogicalSwitchResponse {
 	return mockLogicalSwitchResponse{
 		logicalSwitch: manager.LogicalSwitch{
 			Id:              fakeLogicalSwitchID + "-" + id,
@@ -49,6 +68,18 @@ func buildLogicalSwitchResponse(id string, status string, err error) mockLogical
 		},
 		Status: status,
 		Error:  err,
+	}
+}
+
+func buildLogicalSwitchStatisticsResponse(id string, value int64, err error) mockLogicalSwitchResponse {
+	return mockLogicalSwitchResponse{
+		logicalSwitch: manager.LogicalSwitch{
+			Id:              fakeLogicalSwitchID + "-" + id,
+			DisplayName:     fakeLogicalSwitchDisplayName + "-" + id,
+			TransportZoneId: fakeLogicalSwitchTransportZoneID + "-" + id,
+		},
+		StatisticValue: value,
+		Error:          err,
 	}
 }
 
@@ -61,14 +92,14 @@ func TestLogicalSwitchCollector_GenerateLogicalSwitchStatusMetrics(t *testing.T)
 		{
 			description: "Should return correct status value depending on logical switch state",
 			lswitchResponses: []mockLogicalSwitchResponse{
-				buildLogicalSwitchResponse("01", "SUCCESS", nil),
-				buildLogicalSwitchResponse("02", "PARTIAL_SUCCESS", nil),
-				buildLogicalSwitchResponse("03", "IN_PROGRESS", nil),
-				buildLogicalSwitchResponse("04", "PENDING", nil),
-				buildLogicalSwitchResponse("05", "FAILED", nil),
-				buildLogicalSwitchResponse("06", "ORPHANED", nil),
-				buildLogicalSwitchResponse("07", "Success", nil),
-				buildLogicalSwitchResponse("08", "fAiLeD", nil),
+				buildLogicalSwitchStatusResponse("01", "SUCCESS", nil),
+				buildLogicalSwitchStatusResponse("02", "PARTIAL_SUCCESS", nil),
+				buildLogicalSwitchStatusResponse("03", "IN_PROGRESS", nil),
+				buildLogicalSwitchStatusResponse("04", "PENDING", nil),
+				buildLogicalSwitchStatusResponse("05", "FAILED", nil),
+				buildLogicalSwitchStatusResponse("06", "ORPHANED", nil),
+				buildLogicalSwitchStatusResponse("07", "Success", nil),
+				buildLogicalSwitchStatusResponse("08", "fAiLeD", nil),
 			},
 			expectedMetrics: []logicalSwitchStatusMetric{
 				{
@@ -124,8 +155,8 @@ func TestLogicalSwitchCollector_GenerateLogicalSwitchStatusMetrics(t *testing.T)
 		{
 			description: "Should only return logical switch with valid response",
 			lswitchResponses: []mockLogicalSwitchResponse{
-				buildLogicalSwitchResponse("01", "SUCCESS", nil),
-				buildLogicalSwitchResponse("02", "SUCCESS", errors.New("error get logical switch")),
+				buildLogicalSwitchStatusResponse("01", "SUCCESS", nil),
+				buildLogicalSwitchStatusResponse("02", "SUCCESS", errors.New("error get logical switch")),
 			},
 			expectedMetrics: []logicalSwitchStatusMetric{
 				{
@@ -154,5 +185,86 @@ func TestLogicalSwitchCollector_GenerateLogicalSwitchStatusMetrics(t *testing.T)
 		}
 		lswitchMetrics := lswitchCollector.generateLogicalSwitchStatusMetrics(logicalSwitches)
 		assert.ElementsMatch(t, tc.expectedMetrics, lswitchMetrics, tc.description)
+	}
+}
+
+func TestLogicalSwitchCollector_GenerateLogicalSwitchStatisticsMetrics(t *testing.T) {
+	testcases := []struct {
+		description      string
+		lswitchResponses []mockLogicalSwitchResponse
+		expectedMetrics  []logicalSwitchStatisticMetric
+	}{
+		{
+			description: "Should return correct logical switch statistics value",
+			lswitchResponses: []mockLogicalSwitchResponse{
+				buildLogicalSwitchStatisticsResponse("01", 2, nil),
+				buildLogicalSwitchStatisticsResponse("02", 3, nil),
+			},
+			expectedMetrics: []logicalSwitchStatisticMetric{
+				{
+					ID:              "fake-logical-switch-id-01",
+					Name:            "fake-logical-switch-name-01",
+					TransportZoneID: "fake-transport-zone-id-01",
+					RxByteTotal:     2,
+					RxByteDropped:   2,
+					RxPacketTotal:   2,
+					RxPacketDropped: 2,
+					TxByteTotal:     2,
+					TxByteDropped:   2,
+					TxPacketTotal:   2,
+					TxPacketDropped: 2,
+				}, {
+					ID:              "fake-logical-switch-id-02",
+					Name:            "fake-logical-switch-name-02",
+					TransportZoneID: "fake-transport-zone-id-02",
+					RxByteTotal:     3,
+					RxByteDropped:   3,
+					RxPacketTotal:   3,
+					RxPacketDropped: 3,
+					TxByteTotal:     3,
+					TxByteDropped:   3,
+					TxPacketTotal:   3,
+					TxPacketDropped: 3,
+				},
+			},
+		}, {
+			description: "Should only return logical switch with valid response",
+			lswitchResponses: []mockLogicalSwitchResponse{
+				buildLogicalSwitchStatisticsResponse("01", 2, nil),
+				buildLogicalSwitchStatisticsResponse("02", 3, errors.New("error get logical switch statistic")),
+			},
+			expectedMetrics: []logicalSwitchStatisticMetric{
+				{
+					ID:              "fake-logical-switch-id-01",
+					Name:            "fake-logical-switch-name-01",
+					TransportZoneID: "fake-transport-zone-id-01",
+					RxByteTotal:     2,
+					RxByteDropped:   2,
+					RxPacketTotal:   2,
+					RxPacketDropped: 2,
+					TxByteTotal:     2,
+					TxByteDropped:   2,
+					TxPacketTotal:   2,
+					TxPacketDropped: 2,
+				},
+			},
+		}, {
+			description:      "Should return empty metrics when given empty logical switch",
+			lswitchResponses: []mockLogicalSwitchResponse{},
+			expectedMetrics:  []logicalSwitchStatisticMetric{},
+		},
+	}
+	for _, tc := range testcases {
+		mockLogicalSwitchClient := &mockLogicalSwitchClient{
+			responses: tc.lswitchResponses,
+		}
+		logger := log.NewNopLogger()
+		lswitchCollector := newLogicalSwitchCollector(mockLogicalSwitchClient, logger)
+		var logicalSwitches []manager.LogicalSwitch
+		for _, res := range tc.lswitchResponses {
+			logicalSwitches = append(logicalSwitches, res.logicalSwitch)
+		}
+		metrics := lswitchCollector.generateLogicalSwitchStatisticMetrics(logicalSwitches)
+		assert.ElementsMatch(t, tc.expectedMetrics, metrics, tc.description)
 	}
 }

--- a/collector/logical_switch_collector_test.go
+++ b/collector/logical_switch_collector_test.go
@@ -28,9 +28,9 @@ type mockLogicalSwitchResponse struct {
 	Error           error
 }
 
-func (c *mockLogicalSwitchClient) ListLogicalSwitches(localVarOptionals map[string]interface{}) (manager.LogicalSwitchListResult, error) {
+func (c *mockLogicalSwitchClient) ListAllLogicalSwitches() ([]manager.LogicalSwitch, error) {
 	if c.lswitchListError != nil {
-		return manager.LogicalSwitchListResult{}, c.lswitchListError
+		return nil, c.lswitchListError
 	}
 	var lswitches []manager.LogicalSwitch
 	for _, res := range c.responses {
@@ -41,9 +41,7 @@ func (c *mockLogicalSwitchClient) ListLogicalSwitches(localVarOptionals map[stri
 		}
 		lswitches = append(lswitches, lswitch)
 	}
-	return manager.LogicalSwitchListResult{
-		Results: lswitches,
-	}, nil
+	return lswitches, nil
 }
 
 func (c *mockLogicalSwitchClient) GetLogicalSwitchState(lswitchID string) (manager.LogicalSwitchState, error) {


### PR DESCRIPTION
Add metrics for logical switch statistics and make necessary refactor including:
 - Abstract out method to list all logical switch in NSXT client
 - Change status metric method signature to accept the logical switches
 - Change logical switch collector test to accommodate new test

Signed-off-by: William Albertus Dembo <w.albertusd@gmail.com>