### PR TITLE
Dhcp statistics metrics

### DIFF
--- a/client/nsxt_client.go
+++ b/client/nsxt_client.go
@@ -77,6 +77,11 @@ func (c *nsxtClient) GetDhcpStatus(dhcpID string, localVarOptionals map[string]i
 	return dhcpServerStatus, err
 }
 
+func (c *nsxtClient) GetDHCPStatistic(dhcpID string) (manager.DhcpStatistics, error) {
+	dhcpServerStatistic, _, err := c.apiClient.ServicesApi.GetDhcpStatistics(c.apiClient.Context, dhcpID)
+	return dhcpServerStatistic, err
+}
+
 func (c *nsxtClient) ListAllTransportNodes() ([]manager.TransportNode, error) {
 	var transportNodes []manager.TransportNode
 	var cursor string

--- a/client/nsxt_client.go
+++ b/client/nsxt_client.go
@@ -53,9 +53,23 @@ func (c *nsxtClient) GetLogicalRouterPortStatisticsSummary(lrportID string) (man
 	return lrportsStatus, err
 }
 
-func (c *nsxtClient) ListDhcpServers(localVarOptionals map[string]interface{}) (manager.LogicalDhcpServerListResult, error) {
-	dhcpServersResult, _, err := c.apiClient.ServicesApi.ListDhcpServers(c.apiClient.Context, localVarOptionals)
-	return dhcpServersResult, err
+func (c *nsxtClient) ListAllDHCPServers() ([]manager.LogicalDhcpServer, error) {
+	var dhcps []manager.LogicalDhcpServer
+	var cursor string
+	for {
+		localVarOptionals := make(map[string]interface{})
+		localVarOptionals["cursor"] = cursor
+		dhcpListResponse, _, err := c.apiClient.ServicesApi.ListDhcpServers(c.apiClient.Context, localVarOptionals)
+		if err != nil {
+			return nil, err
+		}
+		dhcps = append(dhcps, dhcpListResponse.Results...)
+		cursor = dhcpListResponse.Cursor
+		if len(cursor) == 0 {
+			break
+		}
+	}
+	return dhcps, nil
 }
 
 func (c *nsxtClient) GetDhcpStatus(dhcpID string, localVarOptionals map[string]interface{}) (manager.DhcpServerStatus, error) {

--- a/client/types.go
+++ b/client/types.go
@@ -21,6 +21,7 @@ type LogicalRouterPortClient interface {
 type DHCPClient interface {
 	ListAllDHCPServers() ([]manager.LogicalDhcpServer, error)
 	GetDhcpStatus(dhcpID string, localVarOptionals map[string]interface{}) (manager.DhcpServerStatus, error)
+	GetDHCPStatistic(dhcpID string) (manager.DhcpStatistics, error)
 }
 
 // TransportNodeClient represents API group Transport Node for NSX-T client.

--- a/client/types.go
+++ b/client/types.go
@@ -19,7 +19,7 @@ type LogicalRouterPortClient interface {
 
 // DHCPClient represents API group DHCP for NSX-T client.
 type DHCPClient interface {
-	ListDhcpServers(localVarOptionals map[string]interface{}) (manager.LogicalDhcpServerListResult, error)
+	ListAllDHCPServers() ([]manager.LogicalDhcpServer, error)
 	GetDhcpStatus(dhcpID string, localVarOptionals map[string]interface{}) (manager.DhcpServerStatus, error)
 }
 

--- a/collector/dhcp_collector.go
+++ b/collector/dhcp_collector.go
@@ -19,13 +19,30 @@ type dhcpCollector struct {
 	dhcpClient client.DHCPClient
 	logger     log.Logger
 
-	dhcpStatus *prometheus.Desc
+	dhcpStatus          *prometheus.Desc
+	dhcpAckPacket       *prometheus.Desc
+	dhcpDeclinePacket   *prometheus.Desc
+	dhcpDiscoverPacket  *prometheus.Desc
+	dhcpErrorTotal      *prometheus.Desc
+	dhcpInformPacket    *prometheus.Desc
+	dhcpNackPacket      *prometheus.Desc
+	dhcpOfferPacket     *prometheus.Desc
+	dhcpReleasePacket   *prometheus.Desc
+	dhcpRequestPacket   *prometheus.Desc
+	dhcpIPPoolSize      *prometheus.Desc
+	dhcpIPPoolAllocated *prometheus.Desc
 }
 
 type dhcpStatusMetric struct {
 	ID     string
 	Name   string
 	Status float64
+}
+
+type dhcpStatisticMetric struct {
+	ID        string
+	Name      string
+	Statistic manager.DhcpStatistics
 }
 
 func createDHCPCollectorFactory(apiClient *nsxt.APIClient, logger log.Logger) prometheus.Collector {
@@ -40,16 +57,104 @@ func newDHCPCollector(dhcpClient client.DHCPClient, logger log.Logger) *dhcpColl
 		[]string{"id", "name"},
 		nil,
 	)
+	dhcpAckPacket := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "dhcp", "ack_packet"),
+		"Number of DHCP ACK packets",
+		[]string{"id", "name"},
+		nil,
+	)
+	dhcpDeclinePacket := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "dhcp", "decline_packet"),
+		"Number of DHCP DECLINE packets",
+		[]string{"id", "name"},
+		nil,
+	)
+	dhcpDiscoverPacket := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "dhcp", "discover_packet"),
+		"Number of DHCP DISCOVER packets",
+		[]string{"id", "name"},
+		nil,
+	)
+	dhcpErrorTotal := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "dhcp", "error_total"),
+		"Number of DHCP errors",
+		[]string{"id", "name"},
+		nil,
+	)
+	dhcpInformPacket := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "dhcp", "inform_packet"),
+		"Number of DHCP INFORM packets",
+		[]string{"id", "name"},
+		nil,
+	)
+	dhcpNackPacket := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "dhcp", "nack_packet"),
+		"Number of DHCP NACK packets",
+		[]string{"id", "name"},
+		nil,
+	)
+	dhcpOfferPacket := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "dhcp", "offer_packet"),
+		"Number of DHCP OFFER packets",
+		[]string{"id", "name"},
+		nil,
+	)
+	dhcpReleasePacket := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "dhcp", "release_packet"),
+		"Number of DHCP RELEASE packets",
+		[]string{"id", "name"},
+		nil,
+	)
+	dhcpRequestPacket := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "dhcp", "request_packet"),
+		"Number of DHCP REQUEST packets",
+		[]string{"id", "name"},
+		nil,
+	)
+	dhcpIPPoolSize := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "dhcp", "ip_pool_size_total"),
+		"Total size of dhcp ip pool",
+		[]string{"id", "dhcp_id"},
+		nil,
+	)
+	dhcpIPPoolAllocated := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "dhcp", "ip_pool_allocated_total"),
+		"Total number of allocated ip of dhcp ip pool",
+		[]string{"id", "dhcp_id"},
+		nil,
+	)
 	return &dhcpCollector{
-		dhcpClient: dhcpClient,
-		logger:     logger,
-		dhcpStatus: dhcpStatus,
+		dhcpClient:          dhcpClient,
+		logger:              logger,
+		dhcpStatus:          dhcpStatus,
+		dhcpAckPacket:       dhcpAckPacket,
+		dhcpDeclinePacket:   dhcpDeclinePacket,
+		dhcpDiscoverPacket:  dhcpDiscoverPacket,
+		dhcpErrorTotal:      dhcpErrorTotal,
+		dhcpInformPacket:    dhcpInformPacket,
+		dhcpNackPacket:      dhcpNackPacket,
+		dhcpOfferPacket:     dhcpOfferPacket,
+		dhcpReleasePacket:   dhcpReleasePacket,
+		dhcpRequestPacket:   dhcpRequestPacket,
+		dhcpIPPoolSize:      dhcpIPPoolSize,
+		dhcpIPPoolAllocated: dhcpIPPoolAllocated,
 	}
 }
 
 // Describe implements the prometheus.Collector interface.
 func (dc *dhcpCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- dc.dhcpStatus
+	ch <- dc.dhcpAckPacket
+	ch <- dc.dhcpDeclinePacket
+	ch <- dc.dhcpDiscoverPacket
+	ch <- dc.dhcpErrorTotal
+	ch <- dc.dhcpInformPacket
+	ch <- dc.dhcpNackPacket
+	ch <- dc.dhcpOfferPacket
+	ch <- dc.dhcpReleasePacket
+	ch <- dc.dhcpRequestPacket
+	ch <- dc.dhcpIPPoolSize
+	ch <- dc.dhcpIPPoolAllocated
 }
 
 // Collect implements the prometheus.Collector interface.
@@ -62,6 +167,24 @@ func (dc *dhcpCollector) Collect(ch chan<- prometheus.Metric) {
 	dhcpStatusMetrics := dc.generateDHCPStatusMetrics(dhcpServers)
 	for _, m := range dhcpStatusMetrics {
 		ch <- prometheus.MustNewConstMetric(dc.dhcpStatus, prometheus.GaugeValue, m.Status, m.ID, m.Name)
+	}
+	dhcpStatisticMetrics := dc.generateDHCPStatisticMetrics(dhcpServers)
+	for _, m := range dhcpStatisticMetrics {
+		dhcpLabels := []string{m.ID, m.Name}
+		ch <- prometheus.MustNewConstMetric(dc.dhcpAckPacket, prometheus.GaugeValue, float64(m.Statistic.Acks), dhcpLabels...)
+		ch <- prometheus.MustNewConstMetric(dc.dhcpDeclinePacket, prometheus.GaugeValue, float64(m.Statistic.Declines), dhcpLabels...)
+		ch <- prometheus.MustNewConstMetric(dc.dhcpDiscoverPacket, prometheus.GaugeValue, float64(m.Statistic.Discovers), dhcpLabels...)
+		ch <- prometheus.MustNewConstMetric(dc.dhcpErrorTotal, prometheus.GaugeValue, float64(m.Statistic.Errors), dhcpLabels...)
+		ch <- prometheus.MustNewConstMetric(dc.dhcpInformPacket, prometheus.GaugeValue, float64(m.Statistic.Informs), dhcpLabels...)
+		ch <- prometheus.MustNewConstMetric(dc.dhcpNackPacket, prometheus.GaugeValue, float64(m.Statistic.Nacks), dhcpLabels...)
+		ch <- prometheus.MustNewConstMetric(dc.dhcpOfferPacket, prometheus.GaugeValue, float64(m.Statistic.Offers), dhcpLabels...)
+		ch <- prometheus.MustNewConstMetric(dc.dhcpReleasePacket, prometheus.GaugeValue, float64(m.Statistic.Releases), dhcpLabels...)
+		ch <- prometheus.MustNewConstMetric(dc.dhcpRequestPacket, prometheus.GaugeValue, float64(m.Statistic.Requests), dhcpLabels...)
+		for _, ipPoolStat := range m.Statistic.IpPoolStats {
+			ipPoolLabels := []string{ipPoolStat.DhcpIpPoolId, m.ID}
+			ch <- prometheus.MustNewConstMetric(dc.dhcpIPPoolSize, prometheus.GaugeValue, float64(ipPoolStat.PoolSize), ipPoolLabels...)
+			ch <- prometheus.MustNewConstMetric(dc.dhcpIPPoolAllocated, prometheus.GaugeValue, float64(ipPoolStat.AllocatedNumber), ipPoolLabels...)
+		}
 	}
 }
 
@@ -84,6 +207,23 @@ func (dc *dhcpCollector) generateDHCPStatusMetrics(dhcpServers []manager.Logical
 			Status: status,
 		}
 		dhcpStatusMetrics = append(dhcpStatusMetrics, dhcpStatusMetric)
+	}
+	return
+}
+
+func (dc *dhcpCollector) generateDHCPStatisticMetrics(dhcpServers []manager.LogicalDhcpServer) (dhcpStatisticMetrics []dhcpStatisticMetric) {
+	for _, dhcp := range dhcpServers {
+		dhcpStatistic, err := dc.dhcpClient.GetDHCPStatistic(dhcp.Id)
+		if err != nil {
+			level.Error(dc.logger).Log("msg", "Unable to get dhcp statistic", "id", dhcp.Id, "err", err)
+			continue
+		}
+		dhcpStatisticMetric := dhcpStatisticMetric{
+			ID:        dhcp.Id,
+			Name:      dhcp.DisplayName,
+			Statistic: dhcpStatistic,
+		}
+		dhcpStatisticMetrics = append(dhcpStatisticMetrics, dhcpStatisticMetric)
 	}
 	return
 }

--- a/collector/dhcp_collector_test.go
+++ b/collector/dhcp_collector_test.go
@@ -25,7 +25,7 @@ type mockDHCPResponse struct {
 	DisplayName string
 	Status      string
 	Error       error
-	Statistic   manager.DhcpStatistics
+	Statistics  manager.DhcpStatistics
 }
 
 func (c *mockDHCPClient) ListAllDHCPServers() ([]manager.LogicalDhcpServer, error) {
@@ -46,7 +46,7 @@ func (c *mockDHCPClient) GetDhcpStatus(dhcpID string, localVarOptionals map[stri
 func (c *mockDHCPClient) GetDHCPStatistic(dhcpID string) (manager.DhcpStatistics, error) {
 	for _, res := range c.responses {
 		if res.ID == dhcpID {
-			return res.Statistic, res.Error
+			return res.Statistics, res.Error
 		}
 	}
 	return manager.DhcpStatistics{}, errors.New("dhcp not found")
@@ -66,7 +66,7 @@ func buildDHCPStatisticResponse(id string, err error) mockDHCPResponse {
 		ID:          fakeDHCPServerID + "-" + id,
 		DisplayName: fakeDHCPServerDisplayName + "-" + id,
 		Error:       err,
-		Statistic: manager.DhcpStatistics{
+		Statistics: manager.DhcpStatistics{
 			Acks:      fakeDHCPStatisticValue,
 			Declines:  fakeDHCPStatisticValue,
 			Discovers: fakeDHCPStatisticValue,


### PR DESCRIPTION
Collect DHCP service and DHCP IP pool statistic metrics including:
 - Number of ack packets
 - Number of decline packets
 - Number of discover packets
 - Number of errors packets
 - Number of informs packets
 - Number of nack packets
 - Number of offer packets
 - Number of release packets
 - Number of request packets
 - IP Pool number of allocated IP
 - IP Pool number of total IP

In the process also refactor:
 - Extract method to list all dhcp server from dhcp status metrics
 - Abstract out the method to list all dhcp server in nsxt client
 - Update dhcp collector test to fit new structure

Signed-off-by: William Albertus Dembo <w.albertusd@gmail.com>