### PR TITLE
Support NAT statistics for logical routers

### DIFF
--- a/client/nsxt_client.go
+++ b/client/nsxt_client.go
@@ -20,6 +20,30 @@ func NewNSXTClient(apiClient *nsxt.APIClient, logger log.Logger) *nsxtClient {
 	}
 }
 
+func (c *nsxtClient) ListAllLogicalRouters() ([]manager.LogicalRouter, error) {
+	var logicalRouters []manager.LogicalRouter
+	var cursor string
+	for {
+		localVarOptionals := make(map[string]interface{})
+		localVarOptionals["cursor"] = cursor
+		logicalRoutersResult, _, err := c.apiClient.LogicalRoutingAndServicesApi.ListLogicalRouters(c.apiClient.Context, localVarOptionals)
+		if err != nil {
+			return nil, err
+		}
+		logicalRouters = append(logicalRouters, logicalRoutersResult.Results...)
+		cursor = logicalRoutersResult.Cursor
+		if len(cursor) == 0 {
+			break
+		}
+	}
+	return logicalRouters, nil
+}
+
+func (c *nsxtClient) GetNatStatisticsPerLogicalRouter(lrouterID string) (manager.NatStatisticsPerLogicalRouter, error) {
+	lrouterResult, _, err := c.apiClient.LogicalRoutingAndServicesApi.GetNatStatisticsPerLogicalRouter(c.apiClient.Context, lrouterID, nil)
+	return lrouterResult, err
+}
+
 func (c *nsxtClient) ListLogicalPorts(localVarOptionals map[string]interface{}) (manager.LogicalPortListResult, error) {
 	lportsResult, _, err := c.apiClient.LogicalSwitchingApi.ListLogicalPorts(c.apiClient.Context, localVarOptionals)
 	return lportsResult, err

--- a/client/nsxt_client.go
+++ b/client/nsxt_client.go
@@ -39,9 +39,30 @@ func (c *nsxtClient) ListAllLogicalRouters() ([]manager.LogicalRouter, error) {
 	return logicalRouters, nil
 }
 
-func (c *nsxtClient) GetNatStatisticsPerLogicalRouter(lrouterID string) (manager.NatStatisticsPerLogicalRouter, error) {
-	lrouterResult, _, err := c.apiClient.LogicalRoutingAndServicesApi.GetNatStatisticsPerLogicalRouter(c.apiClient.Context, lrouterID, nil)
-	return lrouterResult, err
+func (c *nsxtClient) ListAllNatRules(lrouterID string) ([]manager.NatRule, error) {
+	var natRules []manager.NatRule
+	var cursor string
+	for {
+		localVarOptionals := make(map[string]interface{})
+		localVarOptionals["cursor"] = cursor
+		natRulesResult, _, err := c.apiClient.LogicalRoutingAndServicesApi.ListNatRules(c.apiClient.Context, lrouterID, localVarOptionals)
+		if err != nil {
+			return nil, err
+		}
+		natRules = append(natRules, natRulesResult.Results...)
+		cursor = natRulesResult.Cursor
+		if len(cursor) == 0 {
+			break
+		}
+	}
+	return natRules, nil
+}
+
+func (c *nsxtClient) GetNatStatisticsPerRule(lrouterID, ruleID string) (manager.NatStatisticsPerRule, error) {
+	localVarOptionals := make(map[string]interface{})
+	localVarOptionals["source"] = "realtime"
+	natStatsResult, _, err := c.apiClient.LogicalRoutingAndServicesApi.GetNatStatisticsPerRule(c.apiClient.Context, lrouterID, ruleID, localVarOptionals)
+	return natStatsResult, err
 }
 
 func (c *nsxtClient) ListLogicalPorts(localVarOptionals map[string]interface{}) (manager.LogicalPortListResult, error) {

--- a/client/types.go
+++ b/client/types.go
@@ -15,7 +15,8 @@ type LogicalPortClient interface {
 // LogicalRouterClient represents API group logical router for NSX-T client.
 type LogicalRouterClient interface {
 	ListAllLogicalRouters() ([]manager.LogicalRouter, error)
-	GetNatStatisticsPerLogicalRouter(lrouterID string) (manager.NatStatisticsPerLogicalRouter, error)
+	ListAllNatRules(logicalRouterID string) ([]manager.NatRule, error)
+	GetNatStatisticsPerRule(logicalRouterID, ruleID string) (manager.NatStatisticsPerRule, error)
 }
 
 // LogicalRouterPortClient represents API group logical router port for NSX-T client.

--- a/client/types.go
+++ b/client/types.go
@@ -12,6 +12,12 @@ type LogicalPortClient interface {
 	GetLogicalPortOperationalStatus(lportID string, localVarOptionals map[string]interface{}) (manager.LogicalPortOperationalStatus, error)
 }
 
+// LogicalRouterClient represents API group logical router for NSX-T client.
+type LogicalRouterClient interface {
+	ListAllLogicalRouters() ([]manager.LogicalRouter, error)
+	GetNatStatisticsPerLogicalRouter(lrouterID string) (manager.NatStatisticsPerLogicalRouter, error)
+}
+
 // LogicalRouterPortClient represents API group logical router port for NSX-T client.
 type LogicalRouterPortClient interface {
 	ListAllLogicalRouterPorts() ([]manager.LogicalRouterPort, error)

--- a/collector/logical_router_collector.go
+++ b/collector/logical_router_collector.go
@@ -1,0 +1,90 @@
+package collector
+
+import (
+	"nsxt_exporter/client"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	nsxt "github.com/vmware/go-vmware-nsxt"
+	"github.com/vmware/go-vmware-nsxt/manager"
+)
+
+func init() {
+	registerCollector("logical_router", createLogicalRouterCollectorFactory)
+}
+
+type logicalRouterCollector struct {
+	logicalRouterClient client.LogicalRouterClient
+	logger              log.Logger
+
+	natTotalPackets *prometheus.Desc
+	natTotalBytes   *prometheus.Desc
+}
+
+type logicalRouterNatStatisticMetric struct {
+	LogicalRouterID string
+	NatTotalPackets float64
+	NatTotalBytes   float64
+}
+
+func createLogicalRouterCollectorFactory(apiClient *nsxt.APIClient, logger log.Logger) prometheus.Collector {
+	nsxtClient := client.NewNSXTClient(apiClient, logger)
+	return newLogicalRouterCollector(nsxtClient, logger)
+}
+
+func newLogicalRouterCollector(logicalRouterClient client.LogicalRouterClient, logger log.Logger) *logicalRouterCollector {
+	natTotalPackets := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "logical_router", "nat_total_packets"),
+		"Total packets processed by the NAT rule associated with logical router",
+		[]string{"logical_router_id"},
+		nil,
+	)
+	natTotalBytes := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "logical_router", "nat_total_bytes"),
+		"Total bytes processed by the NAT rule associated with logical router",
+		[]string{"logical_router_id"},
+		nil,
+	)
+	return &logicalRouterCollector{
+		logicalRouterClient: logicalRouterClient,
+		logger:              logger,
+		natTotalPackets:     natTotalPackets,
+		natTotalBytes:       natTotalBytes,
+	}
+}
+
+func (c *logicalRouterCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.natTotalPackets
+	ch <- c.natTotalBytes
+}
+
+func (c *logicalRouterCollector) Collect(ch chan<- prometheus.Metric) {
+	logicalRouters, err := c.logicalRouterClient.ListAllLogicalRouters()
+	if err != nil {
+		level.Error(c.logger).Log("msg", "Unable to list logical routers", "err", err)
+		return
+	}
+	logicalRouterNatStatisticMetrics := c.generateLogicalRouterNatStatisticMetrics(logicalRouters)
+	for _, metric := range logicalRouterNatStatisticMetrics {
+		ch <- prometheus.MustNewConstMetric(c.natTotalPackets, prometheus.GaugeValue, metric.NatTotalPackets, metric.LogicalRouterID)
+		ch <- prometheus.MustNewConstMetric(c.natTotalBytes, prometheus.GaugeValue, metric.NatTotalBytes, metric.LogicalRouterID)
+	}
+}
+
+func (c *logicalRouterCollector) generateLogicalRouterNatStatisticMetrics(logicalRouters []manager.LogicalRouter) (logicalRouterNatStatisticMetrics []logicalRouterNatStatisticMetric) {
+	for _, logicalRouter := range logicalRouters {
+		statistic, err := c.logicalRouterClient.GetNatStatisticsPerLogicalRouter(logicalRouter.Id)
+		if err != nil {
+			level.Error(c.logger).Log("msg", "Unable to get logical router statistics", "id", logicalRouter.Id, "err", err)
+			continue
+		}
+		logicalRouterNatStatisticMetric := logicalRouterNatStatisticMetric{
+			LogicalRouterID: logicalRouter.Id,
+			NatTotalPackets: float64(statistic.StatisticsAcrossAllNodes.TotalPackets),
+			NatTotalBytes:   float64(statistic.StatisticsAcrossAllNodes.TotalBytes),
+		}
+		logicalRouterNatStatisticMetrics = append(logicalRouterNatStatisticMetrics, logicalRouterNatStatisticMetric)
+	}
+	return
+}

--- a/collector/logical_router_collector_test.go
+++ b/collector/logical_router_collector_test.go
@@ -1,0 +1,123 @@
+package collector
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/go-vmware-nsxt/manager"
+)
+
+const (
+	fakeLogicalRouterID = "fake-logical-router-id"
+	fakeNatTotalPackets = 1
+	fakeNatTotalBytes   = 1
+)
+
+type mockLogicalRouterClient struct {
+	responses []mockLogicalRouterResponse
+}
+
+type mockLogicalRouterResponse struct {
+	LogicalRouter manager.LogicalRouter
+	Error         error
+
+	NatTotalPackets int64
+	NatTotalBytes   int64
+}
+
+func (c *mockLogicalRouterClient) ListAllLogicalRouters() ([]manager.LogicalRouter, error) {
+	panic("unused function. Only used to satisfy LogicalRouterClient interface")
+}
+
+func (c *mockLogicalRouterClient) GetNatStatisticsPerLogicalRouter(lrouterID string) (manager.NatStatisticsPerLogicalRouter, error) {
+	for _, res := range c.responses {
+		if res.LogicalRouter.Id == lrouterID {
+			return manager.NatStatisticsPerLogicalRouter{
+				StatisticsAcrossAllNodes: &manager.NatCounters{
+					TotalPackets: res.NatTotalPackets,
+					TotalBytes:   res.NatTotalBytes,
+				},
+			}, res.Error
+		}
+	}
+	return manager.NatStatisticsPerLogicalRouter{}, errors.New("error logical router not found")
+}
+
+func buildLogicalRouterResponse(id string, err error) mockLogicalRouterResponse {
+	return mockLogicalRouterResponse{
+		LogicalRouter: manager.LogicalRouter{
+			Id: fmt.Sprintf("%s-%s", fakeLogicalRouterID, id),
+		},
+		Error:           err,
+		NatTotalPackets: fakeNatTotalPackets,
+		NatTotalBytes:   fakeNatTotalBytes,
+	}
+}
+
+func buildLogicalRouters(logicalRouterResponses []mockLogicalRouterResponse) []manager.LogicalRouter {
+	var logicalRouters []manager.LogicalRouter
+	for _, res := range logicalRouterResponses {
+		logicalRouters = append(logicalRouters, res.LogicalRouter)
+	}
+	return logicalRouters
+}
+
+func TestLogicalRouterCollector_GenerateLogicalRouterNatStatisticMetrics(t *testing.T) {
+	testcases := []struct {
+		description            string
+		logicalRouterResponses []mockLogicalRouterResponse
+		expectedMetrics        []logicalRouterNatStatisticMetric
+	}{
+		{
+			description: "Should return correct statistics metrics",
+			logicalRouterResponses: []mockLogicalRouterResponse{
+				buildLogicalRouterResponse("01", nil),
+				buildLogicalRouterResponse("02", nil),
+			},
+			expectedMetrics: []logicalRouterNatStatisticMetric{
+				{
+					LogicalRouterID: fmt.Sprintf("%s-01", fakeLogicalRouterID),
+					NatTotalPackets: fakeNatTotalPackets,
+					NatTotalBytes:   fakeNatTotalBytes,
+				},
+				{
+					LogicalRouterID: fmt.Sprintf("%s-02", fakeLogicalRouterID),
+					NatTotalPackets: fakeNatTotalPackets,
+					NatTotalBytes:   fakeNatTotalBytes,
+				},
+			},
+		},
+		{
+			description: "Should only return statistics with valid response",
+			logicalRouterResponses: []mockLogicalRouterResponse{
+				buildLogicalRouterResponse("01", nil),
+				buildLogicalRouterResponse("02", errors.New("error get logical router nat statistic")),
+			},
+			expectedMetrics: []logicalRouterNatStatisticMetric{
+				{
+					LogicalRouterID: fmt.Sprintf("%s-01", fakeLogicalRouterID),
+					NatTotalPackets: fakeNatTotalPackets,
+					NatTotalBytes:   fakeNatTotalBytes,
+				},
+			},
+		},
+		{
+			description:            "Should return empty metrics when given empty logical router",
+			logicalRouterResponses: []mockLogicalRouterResponse{},
+			expectedMetrics:        []logicalRouterNatStatisticMetric{},
+		},
+	}
+	for _, tc := range testcases {
+		mockLogicalRouterCLient := &mockLogicalRouterClient{
+			responses: tc.logicalRouterResponses,
+		}
+		logger := log.NewNopLogger()
+		lrouterCollector := newLogicalRouterCollector(mockLogicalRouterCLient, logger)
+		logicalRouters := buildLogicalRouters(tc.logicalRouterResponses)
+		metrics := lrouterCollector.generateLogicalRouterNatStatisticMetrics(logicalRouters)
+		assert.ElementsMatch(t, tc.expectedMetrics, metrics, tc.description)
+	}
+}

--- a/collector/logical_router_port_collector_test.go
+++ b/collector/logical_router_port_collector_test.go
@@ -13,7 +13,7 @@ import (
 const (
 	fakeLogicalRouterPortID          = "fake-logical-router-port-id"
 	fakeLogicalRouterPortDisplayName = "fake-logical-router-port-name"
-	fakeLogicalRouterID              = "fake-logical-router-id"
+	fakeLogicalRouterPortRouterID    = "fake-logical-router-id"
 )
 
 type mockLogicalRouterPortClient struct {
@@ -75,7 +75,7 @@ func buildLogicalRouterPortResponse(id string, baseValue int64, err error) mockL
 	return mockLogicalRouterPortResponse{
 		ID:               fmt.Sprintf("%s-%s", fakeLogicalRouterPortID, id),
 		DisplayName:      fmt.Sprintf("%s-%s", fakeLogicalRouterPortDisplayName, id),
-		LogicalRouterID:  fmt.Sprintf("%s-%s", fakeLogicalRouterID, id),
+		LogicalRouterID:  fmt.Sprintf("%s-%s", fakeLogicalRouterPortRouterID, id),
 		Error:            err,
 		RxTotalBytes:     baseValue,
 		RxTotalPackets:   baseValue,


### PR DESCRIPTION
Add support for gathering total packets and bytes from NAT rules
across all transport nodes associated to logical routers.

Addressing #56 

Signed-off-by: Giri Kuncoro <girikuncoro@gmail.com>