### PR TITLE
Restructure DHCP status metric

### DIFF
--- a/collector/dhcp_collector.go
+++ b/collector/dhcp_collector.go
@@ -34,9 +34,10 @@ type dhcpCollector struct {
 }
 
 type dhcpStatusMetric struct {
-	ID     string
-	Name   string
-	Status float64
+	ID         string
+	Name       string
+	Status     float64
+	StatusEnum string
 }
 
 type dhcpStatisticMetric struct {
@@ -202,9 +203,10 @@ func (dc *dhcpCollector) generateDHCPStatusMetrics(dhcpServers []manager.Logical
 			status = 0.0
 		}
 		dhcpStatusMetric := dhcpStatusMetric{
-			Name:   dhcp.DisplayName,
-			ID:     dhcp.Id,
-			Status: status,
+			Name:       dhcp.DisplayName,
+			ID:         dhcp.Id,
+			Status:     status,
+			StatusEnum: strings.ToUpper(dhcpStatus.ServiceStatus),
 		}
 		dhcpStatusMetrics = append(dhcpStatusMetrics, dhcpStatusMetric)
 	}

--- a/collector/dhcp_collector_test.go
+++ b/collector/dhcp_collector_test.go
@@ -222,35 +222,29 @@ func TestDHCPCollector_GenerateDHCPStatusMetrics(t *testing.T) {
 			},
 			expectedMetrics: []dhcpStatusMetric{
 				{
-					ID:         "fake-dhcp-server-id-01",
-					Name:       "fake-dhcp-server-name-01",
-					Status:     1.0,
-					StatusEnum: "UP",
+					ID:     "fake-dhcp-server-id-01",
+					Name:   "fake-dhcp-server-name-01",
+					Status: "UP",
 				}, {
-					ID:         "fake-dhcp-server-id-02",
-					Name:       "fake-dhcp-server-name-02",
-					Status:     0.0,
-					StatusEnum: "DOWN",
+					ID:     "fake-dhcp-server-id-02",
+					Name:   "fake-dhcp-server-name-02",
+					Status: "DOWN",
 				}, {
-					ID:         "fake-dhcp-server-id-03",
-					Name:       "fake-dhcp-server-name-03",
-					Status:     0.0,
-					StatusEnum: "ERROR",
+					ID:     "fake-dhcp-server-id-03",
+					Name:   "fake-dhcp-server-name-03",
+					Status: "ERROR",
 				}, {
-					ID:         "fake-dhcp-server-id-04",
-					Name:       "fake-dhcp-server-name-04",
-					Status:     0.0,
-					StatusEnum: "NO_STANDBY",
+					ID:     "fake-dhcp-server-id-04",
+					Name:   "fake-dhcp-server-name-04",
+					Status: "NO_STANDBY",
 				}, {
-					ID:         "fake-dhcp-server-id-05",
-					Name:       "fake-dhcp-server-name-05",
-					Status:     1.0,
-					StatusEnum: "UP",
+					ID:     "fake-dhcp-server-id-05",
+					Name:   "fake-dhcp-server-name-05",
+					Status: "UP",
 				}, {
-					ID:         "fake-dhcp-server-id-06",
-					Name:       "fake-dhcp-server-name-06",
-					Status:     0.0,
-					StatusEnum: "DOWN",
+					ID:     "fake-dhcp-server-id-06",
+					Name:   "fake-dhcp-server-name-06",
+					Status: "DOWN",
 				},
 			},
 		}, {
@@ -261,10 +255,9 @@ func TestDHCPCollector_GenerateDHCPStatusMetrics(t *testing.T) {
 			},
 			expectedMetrics: []dhcpStatusMetric{
 				{
-					ID:         "fake-dhcp-server-id-01",
-					Name:       "fake-dhcp-server-name-01",
-					Status:     1.0,
-					StatusEnum: "UP",
+					ID:     "fake-dhcp-server-id-01",
+					Name:   "fake-dhcp-server-name-01",
+					Status: "UP",
 				},
 			},
 		}, {

--- a/collector/dhcp_collector_test.go
+++ b/collector/dhcp_collector_test.go
@@ -222,29 +222,59 @@ func TestDHCPCollector_GenerateDHCPStatusMetrics(t *testing.T) {
 			},
 			expectedMetrics: []dhcpStatusMetric{
 				{
-					ID:     "fake-dhcp-server-id-01",
-					Name:   "fake-dhcp-server-name-01",
-					Status: "UP",
+					ID:   "fake-dhcp-server-id-01",
+					Name: "fake-dhcp-server-name-01",
+					StatusDetail: map[string]float64{
+						"UP":         1.0,
+						"DOWN":       0.0,
+						"ERROR":      0.0,
+						"NO_STANDBY": 0.0,
+					},
 				}, {
-					ID:     "fake-dhcp-server-id-02",
-					Name:   "fake-dhcp-server-name-02",
-					Status: "DOWN",
+					ID:   "fake-dhcp-server-id-02",
+					Name: "fake-dhcp-server-name-02",
+					StatusDetail: map[string]float64{
+						"UP":         0.0,
+						"DOWN":       1.0,
+						"ERROR":      0.0,
+						"NO_STANDBY": 0.0,
+					},
 				}, {
-					ID:     "fake-dhcp-server-id-03",
-					Name:   "fake-dhcp-server-name-03",
-					Status: "ERROR",
+					ID:   "fake-dhcp-server-id-03",
+					Name: "fake-dhcp-server-name-03",
+					StatusDetail: map[string]float64{
+						"UP":         0.0,
+						"DOWN":       0.0,
+						"ERROR":      1.0,
+						"NO_STANDBY": 0.0,
+					},
 				}, {
-					ID:     "fake-dhcp-server-id-04",
-					Name:   "fake-dhcp-server-name-04",
-					Status: "NO_STANDBY",
+					ID:   "fake-dhcp-server-id-04",
+					Name: "fake-dhcp-server-name-04",
+					StatusDetail: map[string]float64{
+						"UP":         0.0,
+						"DOWN":       0.0,
+						"ERROR":      0.0,
+						"NO_STANDBY": 1.0,
+					},
 				}, {
-					ID:     "fake-dhcp-server-id-05",
-					Name:   "fake-dhcp-server-name-05",
-					Status: "UP",
+					ID:   "fake-dhcp-server-id-05",
+					Name: "fake-dhcp-server-name-05",
+					StatusDetail: map[string]float64{
+						"UP":         1.0,
+						"DOWN":       0.0,
+						"ERROR":      0.0,
+						"NO_STANDBY": 0.0,
+					},
 				}, {
-					ID:     "fake-dhcp-server-id-06",
-					Name:   "fake-dhcp-server-name-06",
-					Status: "DOWN",
+					ID:   "fake-dhcp-server-id-06",
+					Name: "fake-dhcp-server-name-06",
+					StatusDetail: map[string]float64{
+						"UP":         0.0,
+						"DOWN":       1.0,
+						"ERROR":      0.0,
+						"NO_STANDBY": 0.0,
+					},
 				},
 			},
 		}, {
@@ -255,9 +285,14 @@ func TestDHCPCollector_GenerateDHCPStatusMetrics(t *testing.T) {
 			},
 			expectedMetrics: []dhcpStatusMetric{
 				{
-					ID:     "fake-dhcp-server-id-01",
-					Name:   "fake-dhcp-server-name-01",
-					Status: "UP",
+					ID:   "fake-dhcp-server-id-01",
+					Name: "fake-dhcp-server-name-01",
+					StatusDetail: map[string]float64{
+						"UP":         1.0,
+						"DOWN":       0.0,
+						"ERROR":      0.0,
+						"NO_STANDBY": 0.0,
+					},
 				},
 			},
 		}, {

--- a/collector/dhcp_collector_test.go
+++ b/collector/dhcp_collector_test.go
@@ -222,38 +222,38 @@ func TestDHCPCollector_GenerateDHCPStatusMetrics(t *testing.T) {
 			},
 			expectedMetrics: []dhcpStatusMetric{
 				{
-					ID:     "fake-dhcp-server-id-01",
-					Name:   "fake-dhcp-server-name-01",
-					Status: 1.0,
-				},
-				{
-					ID:     "fake-dhcp-server-id-02",
-					Name:   "fake-dhcp-server-name-02",
-					Status: 0.0,
-				},
-				{
-					ID:     "fake-dhcp-server-id-03",
-					Name:   "fake-dhcp-server-name-03",
-					Status: 0.0,
-				},
-				{
-					ID:     "fake-dhcp-server-id-04",
-					Name:   "fake-dhcp-server-name-04",
-					Status: 0.0,
-				},
-				{
-					ID:     "fake-dhcp-server-id-05",
-					Name:   "fake-dhcp-server-name-05",
-					Status: 1.0,
-				},
-				{
-					ID:     "fake-dhcp-server-id-06",
-					Name:   "fake-dhcp-server-name-06",
-					Status: 0.0,
+					ID:         "fake-dhcp-server-id-01",
+					Name:       "fake-dhcp-server-name-01",
+					Status:     1.0,
+					StatusEnum: "UP",
+				}, {
+					ID:         "fake-dhcp-server-id-02",
+					Name:       "fake-dhcp-server-name-02",
+					Status:     0.0,
+					StatusEnum: "DOWN",
+				}, {
+					ID:         "fake-dhcp-server-id-03",
+					Name:       "fake-dhcp-server-name-03",
+					Status:     0.0,
+					StatusEnum: "ERROR",
+				}, {
+					ID:         "fake-dhcp-server-id-04",
+					Name:       "fake-dhcp-server-name-04",
+					Status:     0.0,
+					StatusEnum: "NO_STANDBY",
+				}, {
+					ID:         "fake-dhcp-server-id-05",
+					Name:       "fake-dhcp-server-name-05",
+					Status:     1.0,
+					StatusEnum: "UP",
+				}, {
+					ID:         "fake-dhcp-server-id-06",
+					Name:       "fake-dhcp-server-name-06",
+					Status:     0.0,
+					StatusEnum: "DOWN",
 				},
 			},
-		},
-		{
+		}, {
 			description: "Should only return dhcp server with valid response",
 			dhcpResponses: []mockDHCPResponse{
 				buildDHCPStatusResponse("01", "UP", nil),
@@ -261,13 +261,13 @@ func TestDHCPCollector_GenerateDHCPStatusMetrics(t *testing.T) {
 			},
 			expectedMetrics: []dhcpStatusMetric{
 				{
-					ID:     "fake-dhcp-server-id-01",
-					Name:   "fake-dhcp-server-name-01",
-					Status: 1.0,
+					ID:         "fake-dhcp-server-id-01",
+					Name:       "fake-dhcp-server-name-01",
+					Status:     1.0,
+					StatusEnum: "UP",
 				},
 			},
-		},
-		{
+		}, {
 			dhcpResponses:   []mockDHCPResponse{},
 			expectedMetrics: []dhcpStatusMetric{},
 		},


### PR DESCRIPTION
Change the DHCP status metric from the value of UP/DOWN to more detailed metrics to capture status enum.

Address #59 

Signed-off-by: William Albertus Dembo <w.albertusd@gmail.com>