### PR TITLE
Add logical router status collector

### DIFF
--- a/client/nsxt_client.go
+++ b/client/nsxt_client.go
@@ -39,6 +39,11 @@ func (c *nsxtClient) ListAllLogicalRouters() ([]manager.LogicalRouter, error) {
 	return logicalRouters, nil
 }
 
+func (c *nsxtClient) GetLogicalRouterStatus(lrouterID string) (manager.LogicalRouterStatus, error) {
+	lrouterStatus, _, err := c.apiClient.LogicalRoutingAndServicesApi.GetLogicalRouterStatus(c.apiClient.Context, lrouterID, nil)
+	return lrouterStatus, err
+}
+
 func (c *nsxtClient) ListAllNatRules(lrouterID string) ([]manager.NatRule, error) {
 	var natRules []manager.NatRule
 	var cursor string

--- a/client/types.go
+++ b/client/types.go
@@ -15,6 +15,7 @@ type LogicalPortClient interface {
 // LogicalRouterClient represents API group logical router for NSX-T client.
 type LogicalRouterClient interface {
 	ListAllLogicalRouters() ([]manager.LogicalRouter, error)
+	GetLogicalRouterStatus(logicalRouterID string) (manager.LogicalRouterStatus, error)
 	ListAllNatRules(logicalRouterID string) ([]manager.NatRule, error)
 	GetNatStatisticsPerRule(logicalRouterID, ruleID string) (manager.NatStatisticsPerRule, error)
 }

--- a/collector/logical_router_collector.go
+++ b/collector/logical_router_collector.go
@@ -18,8 +18,17 @@ type logicalRouterCollector struct {
 	logicalRouterClient client.LogicalRouterClient
 	logger              log.Logger
 
+	logicalRouterStatus *prometheus.Desc
 	natRuleTotalPackets *prometheus.Desc
 	natRuleTotalBytes   *prometheus.Desc
+}
+
+type logicalRouterStatusMetric struct {
+	ID                     string
+	Name                   string
+	TransportNodeID        string
+	ServiceRouterID        string
+	HighAvailabilityStatus string
 }
 
 type natRuleStatisticMetric struct {
@@ -36,6 +45,12 @@ func createLogicalRouterCollectorFactory(apiClient *nsxt.APIClient, logger log.L
 }
 
 func newLogicalRouterCollector(logicalRouterClient client.LogicalRouterClient, logger log.Logger) *logicalRouterCollector {
+	logicalRouterStatus := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "logical_router", "status"),
+		"Status of logical router which includes high availability status associated with transport node",
+		[]string{"id", "name", "transport_node_id", "service_router_id", "high_availability_status"},
+		nil,
+	)
 	natRuleTotalPackets := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "nat_rule", "total_packets"),
 		"Total packets processed by the NAT rule associated with logical router",
@@ -51,12 +66,14 @@ func newLogicalRouterCollector(logicalRouterClient client.LogicalRouterClient, l
 	return &logicalRouterCollector{
 		logicalRouterClient: logicalRouterClient,
 		logger:              logger,
+		logicalRouterStatus: logicalRouterStatus,
 		natRuleTotalPackets: natRuleTotalPackets,
 		natRuleTotalBytes:   natRuleTotalBytes,
 	}
 }
 
 func (c *logicalRouterCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.logicalRouterStatus
 	ch <- c.natRuleTotalPackets
 	ch <- c.natRuleTotalBytes
 }
@@ -67,12 +84,38 @@ func (c *logicalRouterCollector) Collect(ch chan<- prometheus.Metric) {
 		level.Error(c.logger).Log("msg", "Unable to list logical routers", "err", err)
 		return
 	}
-	natRuleStatisticMetrics := c.generateNatRuleStatisticMetrics(logicalRouters)
-	for _, metric := range natRuleStatisticMetrics {
-		labels := []string{metric.ID, metric.Name, metric.LogicalRouterID}
-		ch <- prometheus.MustNewConstMetric(c.natRuleTotalPackets, prometheus.GaugeValue, metric.NatTotalPackets, labels...)
-		ch <- prometheus.MustNewConstMetric(c.natRuleTotalBytes, prometheus.GaugeValue, metric.NatTotalBytes, labels...)
+	logicalRouterStatusMetrics := c.generateLogicalRouterStatusMetrics(logicalRouters)
+	for _, lrouterMetric := range logicalRouterStatusMetrics {
+		labels := []string{lrouterMetric.ID, lrouterMetric.Name, lrouterMetric.TransportNodeID, lrouterMetric.ServiceRouterID, lrouterMetric.HighAvailabilityStatus}
+		ch <- prometheus.MustNewConstMetric(c.logicalRouterStatus, prometheus.GaugeValue, 1.0, labels...)
 	}
+	natRuleStatisticMetrics := c.generateNatRuleStatisticMetrics(logicalRouters)
+	for _, natMetric := range natRuleStatisticMetrics {
+		labels := []string{natMetric.ID, natMetric.Name, natMetric.LogicalRouterID}
+		ch <- prometheus.MustNewConstMetric(c.natRuleTotalPackets, prometheus.GaugeValue, natMetric.NatTotalPackets, labels...)
+		ch <- prometheus.MustNewConstMetric(c.natRuleTotalBytes, prometheus.GaugeValue, natMetric.NatTotalBytes, labels...)
+	}
+}
+
+func (c *logicalRouterCollector) generateLogicalRouterStatusMetrics(logicalRouters []manager.LogicalRouter) (logicalRouterStatusMetrics []logicalRouterStatusMetric) {
+	for _, logicalRouter := range logicalRouters {
+		lrouterStatus, err := c.logicalRouterClient.GetLogicalRouterStatus(logicalRouter.Id)
+		if err != nil {
+			level.Error(c.logger).Log("msg", "Unable to get logical router status", "id", logicalRouter.Id, "err", err)
+			continue
+		}
+		for _, status := range lrouterStatus.PerNodeStatus {
+			logicalRouterStatusMetric := logicalRouterStatusMetric{
+				ID:                     logicalRouter.Id,
+				Name:                   logicalRouter.DisplayName,
+				TransportNodeID:        status.TransportNodeId,
+				ServiceRouterID:        status.ServiceRouterId,
+				HighAvailabilityStatus: status.HighAvailabilityStatus,
+			}
+			logicalRouterStatusMetrics = append(logicalRouterStatusMetrics, logicalRouterStatusMetric)
+		}
+	}
+	return
 }
 
 func (c *logicalRouterCollector) generateNatRuleStatisticMetrics(logicalRouters []manager.LogicalRouter) (natRuleStatisticMetrics []natRuleStatisticMetric) {

--- a/collector/logical_router_collector_test.go
+++ b/collector/logical_router_collector_test.go
@@ -139,6 +139,15 @@ func buildLogicalRouters(logicalRouterResponses []mockLogicalRouterResponse) []m
 	return logicalRouters
 }
 
+func buildExpectedHighAvailabilityStatusDetails(nonZeroStatus string) map[string]float64 {
+	statusDetails := map[string]float64{
+		"ACTIVE":  0.0,
+		"STANDBY": 0.0,
+	}
+	statusDetails[nonZeroStatus] = 1.0
+	return statusDetails
+}
+
 func TestLogicalRouterCollector_GenerateLogicalRouterStatusMetrics(t *testing.T) {
 	testcases := []struct {
 		description            string
@@ -153,25 +162,25 @@ func TestLogicalRouterCollector_GenerateLogicalRouterStatusMetrics(t *testing.T)
 			},
 			expectedMetrics: []logicalRouterStatusMetric{
 				{
-					ID:                     fmt.Sprintf("%s-1", fakeLogicalRouterID),
-					Name:                   fmt.Sprintf("%s-1", fakeLogicalRouterName),
-					TransportNodeID:        fakeLogicalRouterTransportNodeID,
-					ServiceRouterID:        fakeLogicalRouterServiceRouterID,
-					HighAvailabilityStatus: "ACTIVE",
+					ID:                           fmt.Sprintf("%s-1", fakeLogicalRouterID),
+					Name:                         fmt.Sprintf("%s-1", fakeLogicalRouterName),
+					TransportNodeID:              fakeLogicalRouterTransportNodeID,
+					ServiceRouterID:              fakeLogicalRouterServiceRouterID,
+					HighAvailabilityStatusDetail: buildExpectedHighAvailabilityStatusDetails("ACTIVE"),
 				},
 				{
-					ID:                     fmt.Sprintf("%s-1", fakeLogicalRouterID),
-					Name:                   fmt.Sprintf("%s-1", fakeLogicalRouterName),
-					TransportNodeID:        fakeLogicalRouterTransportNodeID,
-					ServiceRouterID:        fakeLogicalRouterServiceRouterID,
-					HighAvailabilityStatus: "STANDBY",
+					ID:                           fmt.Sprintf("%s-1", fakeLogicalRouterID),
+					Name:                         fmt.Sprintf("%s-1", fakeLogicalRouterName),
+					TransportNodeID:              fakeLogicalRouterTransportNodeID,
+					ServiceRouterID:              fakeLogicalRouterServiceRouterID,
+					HighAvailabilityStatusDetail: buildExpectedHighAvailabilityStatusDetails("STANDBY"),
 				},
 				{
-					ID:                     fmt.Sprintf("%s-2", fakeLogicalRouterID),
-					Name:                   fmt.Sprintf("%s-2", fakeLogicalRouterName),
-					TransportNodeID:        fakeLogicalRouterTransportNodeID,
-					ServiceRouterID:        fakeLogicalRouterServiceRouterID,
-					HighAvailabilityStatus: "ACTIVE",
+					ID:                           fmt.Sprintf("%s-2", fakeLogicalRouterID),
+					Name:                         fmt.Sprintf("%s-2", fakeLogicalRouterName),
+					TransportNodeID:              fakeLogicalRouterTransportNodeID,
+					ServiceRouterID:              fakeLogicalRouterServiceRouterID,
+					HighAvailabilityStatusDetail: buildExpectedHighAvailabilityStatusDetails("ACTIVE"),
 				},
 			},
 		},
@@ -183,11 +192,11 @@ func TestLogicalRouterCollector_GenerateLogicalRouterStatusMetrics(t *testing.T)
 			},
 			expectedMetrics: []logicalRouterStatusMetric{
 				{
-					ID:                     fmt.Sprintf("%s-2", fakeLogicalRouterID),
-					Name:                   fmt.Sprintf("%s-2", fakeLogicalRouterName),
-					TransportNodeID:        fakeLogicalRouterTransportNodeID,
-					ServiceRouterID:        fakeLogicalRouterServiceRouterID,
-					HighAvailabilityStatus: "ACTIVE",
+					ID:                           fmt.Sprintf("%s-2", fakeLogicalRouterID),
+					Name:                         fmt.Sprintf("%s-2", fakeLogicalRouterName),
+					TransportNodeID:              fakeLogicalRouterTransportNodeID,
+					ServiceRouterID:              fakeLogicalRouterServiceRouterID,
+					HighAvailabilityStatusDetail: buildExpectedHighAvailabilityStatusDetails("ACTIVE"),
 				},
 			},
 		},

--- a/collector/logical_router_collector_test.go
+++ b/collector/logical_router_collector_test.go
@@ -11,11 +11,14 @@ import (
 )
 
 const (
-	fakeLogicalRouterID = "fake-logical-router-id"
-	fakeNatRuleID       = "fake-nat-rule-id"
-	fakeNatRuleName     = "fake-nat-rule-name"
-	fakeNatTotalPackets = 1
-	fakeNatTotalBytes   = 1
+	fakeLogicalRouterID              = "fake-logical-router-id"
+	fakeLogicalRouterName            = "fake-logical-router-name"
+	fakeLogicalRouterServiceRouterID = "fake-service-router-id"
+	fakeLogicalRouterTransportNodeID = "fake-transport-node-id"
+	fakeNatRuleID                    = "fake-nat-rule-id"
+	fakeNatRuleName                  = "fake-nat-rule-name"
+	fakeNatTotalPackets              = 1
+	fakeNatTotalBytes                = 1
 )
 
 type mockLogicalRouterClient struct {
@@ -24,9 +27,10 @@ type mockLogicalRouterClient struct {
 }
 
 type mockLogicalRouterResponse struct {
-	LogicalRouter manager.LogicalRouter
-	NatRules      []manager.NatRule
-	Error         error
+	LogicalRouter       manager.LogicalRouter
+	LogicalRouterStatus []manager.LogicalRouterStatusPerNode
+	NatRules            []manager.NatRule
+	Error               error
 
 	NatTotalPackets int64
 	NatTotalBytes   int64
@@ -34,6 +38,18 @@ type mockLogicalRouterResponse struct {
 
 func (c *mockLogicalRouterClient) ListAllLogicalRouters() ([]manager.LogicalRouter, error) {
 	panic("unused function. Only used to satisfy LogicalRouterClient interface")
+}
+
+func (c *mockLogicalRouterClient) GetLogicalRouterStatus(lrouterID string) (manager.LogicalRouterStatus, error) {
+	for _, res := range c.responses {
+		if res.LogicalRouter.Id == lrouterID {
+			return manager.LogicalRouterStatus{
+				LogicalRouterId: lrouterID,
+				PerNodeStatus:   res.LogicalRouterStatus,
+			}, res.Error
+		}
+	}
+	return manager.LogicalRouterStatus{}, errors.New("error logical router not found")
 }
 
 func (c *mockLogicalRouterClient) ListAllNatRules(lrouterID string) ([]manager.NatRule, error) {
@@ -77,7 +93,26 @@ func (c *mockLogicalRouterClient) GetNatStatisticsPerRule(lrouterID, ruleID stri
 	return manager.NatStatisticsPerRule{}, errors.New("error nat rule not found")
 }
 
-func buildLogicalRouterResponse(lrouterID string, ruleIDs []string, err error) mockLogicalRouterResponse {
+func buildLogicalRouterResponseWithStatus(lrouterID string, highAvailabilityStatus []string, err error) mockLogicalRouterResponse {
+	var lrouterStatus []manager.LogicalRouterStatusPerNode
+	for _, status := range highAvailabilityStatus {
+		lrouterStatus = append(lrouterStatus, manager.LogicalRouterStatusPerNode{
+			HighAvailabilityStatus: status,
+			ServiceRouterId:        fakeLogicalRouterServiceRouterID,
+			TransportNodeId:        fakeLogicalRouterTransportNodeID,
+		})
+	}
+	return mockLogicalRouterResponse{
+		LogicalRouter: manager.LogicalRouter{
+			Id:          fmt.Sprintf("%s-%s", fakeLogicalRouterID, lrouterID),
+			DisplayName: fmt.Sprintf("%s-%s", fakeLogicalRouterName, lrouterID),
+		},
+		LogicalRouterStatus: lrouterStatus,
+		Error:               err,
+	}
+}
+
+func buildLogicalRouterResponseWithNatRules(lrouterID string, ruleIDs []string, err error) mockLogicalRouterResponse {
 	var natRules []manager.NatRule
 	for _, ruleID := range ruleIDs {
 		natRules = append(natRules, manager.NatRule{
@@ -104,6 +139,76 @@ func buildLogicalRouters(logicalRouterResponses []mockLogicalRouterResponse) []m
 	return logicalRouters
 }
 
+func TestLogicalRouterCollector_GenerateLogicalRouterStatusMetrics(t *testing.T) {
+	testcases := []struct {
+		description            string
+		logicalRouterResponses []mockLogicalRouterResponse
+		expectedMetrics        []logicalRouterStatusMetric
+	}{
+		{
+			description: "Should return correct status metrics",
+			logicalRouterResponses: []mockLogicalRouterResponse{
+				buildLogicalRouterResponseWithStatus("1", []string{"ACTIVE", "STANDBY"}, nil),
+				buildLogicalRouterResponseWithStatus("2", []string{"ACTIVE"}, nil),
+			},
+			expectedMetrics: []logicalRouterStatusMetric{
+				{
+					ID:                     fmt.Sprintf("%s-1", fakeLogicalRouterID),
+					Name:                   fmt.Sprintf("%s-1", fakeLogicalRouterName),
+					TransportNodeID:        fakeLogicalRouterTransportNodeID,
+					ServiceRouterID:        fakeLogicalRouterServiceRouterID,
+					HighAvailabilityStatus: "ACTIVE",
+				},
+				{
+					ID:                     fmt.Sprintf("%s-1", fakeLogicalRouterID),
+					Name:                   fmt.Sprintf("%s-1", fakeLogicalRouterName),
+					TransportNodeID:        fakeLogicalRouterTransportNodeID,
+					ServiceRouterID:        fakeLogicalRouterServiceRouterID,
+					HighAvailabilityStatus: "STANDBY",
+				},
+				{
+					ID:                     fmt.Sprintf("%s-2", fakeLogicalRouterID),
+					Name:                   fmt.Sprintf("%s-2", fakeLogicalRouterName),
+					TransportNodeID:        fakeLogicalRouterTransportNodeID,
+					ServiceRouterID:        fakeLogicalRouterServiceRouterID,
+					HighAvailabilityStatus: "ACTIVE",
+				},
+			},
+		},
+		{
+			description: "Should only return status with valid response",
+			logicalRouterResponses: []mockLogicalRouterResponse{
+				buildLogicalRouterResponseWithStatus("1", []string{"ACTIVE", "STANDBY"}, errors.New("error get logical router status")),
+				buildLogicalRouterResponseWithStatus("2", []string{"ACTIVE"}, nil),
+			},
+			expectedMetrics: []logicalRouterStatusMetric{
+				{
+					ID:                     fmt.Sprintf("%s-2", fakeLogicalRouterID),
+					Name:                   fmt.Sprintf("%s-2", fakeLogicalRouterName),
+					TransportNodeID:        fakeLogicalRouterTransportNodeID,
+					ServiceRouterID:        fakeLogicalRouterServiceRouterID,
+					HighAvailabilityStatus: "ACTIVE",
+				},
+			},
+		},
+		{
+			description:            "Should return empty metrics when empty response",
+			logicalRouterResponses: []mockLogicalRouterResponse{},
+			expectedMetrics:        []logicalRouterStatusMetric{},
+		},
+	}
+	for _, tc := range testcases {
+		mockLogicalRouterClient := &mockLogicalRouterClient{
+			responses: tc.logicalRouterResponses,
+		}
+		logger := log.NewNopLogger()
+		lrouterCollector := newLogicalRouterCollector(mockLogicalRouterClient, logger)
+		logicalRouters := buildLogicalRouters(tc.logicalRouterResponses)
+		metrics := lrouterCollector.generateLogicalRouterStatusMetrics(logicalRouters)
+		assert.ElementsMatch(t, tc.expectedMetrics, metrics, tc.description)
+	}
+}
+
 func TestLogicalRouterCollector_GenerateLogicalRouterNatStatisticMetrics(t *testing.T) {
 	testcases := []struct {
 		description            string
@@ -114,8 +219,8 @@ func TestLogicalRouterCollector_GenerateLogicalRouterNatStatisticMetrics(t *test
 		{
 			description: "Should return correct statistics metrics",
 			logicalRouterResponses: []mockLogicalRouterResponse{
-				buildLogicalRouterResponse("1", []string{"1", "2"}, nil),
-				buildLogicalRouterResponse("2", []string{"3"}, nil),
+				buildLogicalRouterResponseWithNatRules("1", []string{"1", "2"}, nil),
+				buildLogicalRouterResponseWithNatRules("2", []string{"3"}, nil),
 			},
 			expectedMetrics: []natRuleStatisticMetric{
 				{
@@ -144,8 +249,8 @@ func TestLogicalRouterCollector_GenerateLogicalRouterNatStatisticMetrics(t *test
 		{
 			description: "Should only return statistics with valid response",
 			logicalRouterResponses: []mockLogicalRouterResponse{
-				buildLogicalRouterResponse("1", []string{"1", "2"}, errors.New("error get nat rule statistic")),
-				buildLogicalRouterResponse("2", []string{"3"}, nil),
+				buildLogicalRouterResponseWithNatRules("1", []string{"1", "2"}, errors.New("error get nat rule statistic")),
+				buildLogicalRouterResponseWithNatRules("2", []string{"3"}, nil),
 			},
 			expectedMetrics: []natRuleStatisticMetric{
 				{
@@ -170,14 +275,13 @@ func TestLogicalRouterCollector_GenerateLogicalRouterNatStatisticMetrics(t *test
 		},
 	}
 	for _, tc := range testcases {
-		mockLogicalRouterCLient := &mockLogicalRouterClient{
+		mockLogicalRouterClient := &mockLogicalRouterClient{
 			responses: tc.logicalRouterResponses,
 		}
 		logger := log.NewNopLogger()
-		lrouterCollector := newLogicalRouterCollector(mockLogicalRouterCLient, logger)
+		lrouterCollector := newLogicalRouterCollector(mockLogicalRouterClient, logger)
 		logicalRouters := buildLogicalRouters(tc.logicalRouterResponses)
 		metrics := lrouterCollector.generateNatRuleStatisticMetrics(logicalRouters)
-		fmt.Println(metrics)
 		assert.ElementsMatch(t, tc.expectedMetrics, metrics, tc.description)
 	}
 }


### PR DESCRIPTION
Logical router status API doesn't provide explicit health status of
logical router, the logical router status is bound to transport node.
So, this commit generates status from each transport node and assume 1.0
as status.

Signed-off-by: Giri Kuncoro <girikuncoro@gmail.com>