### PR TITLE
Add firewall statistic collector

### DIFF
--- a/client/nsxt_client.go
+++ b/client/nsxt_client.go
@@ -293,3 +293,46 @@ func (c *nsxtClient) GetLoadBalancerStatus(loadBalancerID string) (loadbalancer.
 	loadBalancerStatus, _, err := c.apiClient.ServicesApi.ReadLoadBalancerServiceStatus(c.apiClient.Context, loadBalancerID, nil)
 	return loadBalancerStatus, err
 }
+
+func (c *nsxtClient) ListAllSections() ([]manager.FirewallSection, error) {
+	var firewallSections []manager.FirewallSection
+	var cursor string
+	for {
+		localVarOptionals := make(map[string]interface{})
+		localVarOptionals["cursor"] = cursor
+		firewallSectionsResult, _, err := c.apiClient.ServicesApi.ListSections(c.apiClient.Context, localVarOptionals)
+		if err != nil {
+			return nil, err
+		}
+		firewallSections = append(firewallSections, firewallSectionsResult.Results...)
+		cursor = firewallSectionsResult.Cursor
+		if len(cursor) == 0 {
+			break
+		}
+	}
+	return firewallSections, nil
+}
+
+func (c *nsxtClient) GetAllRules(sectionID string) ([]manager.FirewallRule, error) {
+	var firewallRules []manager.FirewallRule
+	var cursor string
+	for {
+		localVarOptionals := make(map[string]interface{})
+		localVarOptionals["cursor"] = cursor
+		firewallRulesResult, _, err := c.apiClient.ServicesApi.GetRules(c.apiClient.Context, sectionID, localVarOptionals)
+		if err != nil {
+			return nil, err
+		}
+		firewallRules = append(firewallRules, firewallRulesResult.Results...)
+		cursor = firewallRulesResult.Cursor
+		if len(cursor) == 0 {
+			break
+		}
+	}
+	return firewallRules, nil
+}
+
+func (c *nsxtClient) GetFirewallStats(sectionID, ruleID string) (manager.FirewallStats, error) {
+	firewallStats, _, err := c.apiClient.ServicesApi.GetFirewallStats(c.apiClient.Context, sectionID, ruleID, nil)
+	return firewallStats, err
+}

--- a/client/nsxt_client.go
+++ b/client/nsxt_client.go
@@ -294,7 +294,7 @@ func (c *nsxtClient) GetLoadBalancerStatus(loadBalancerID string) (loadbalancer.
 	return loadBalancerStatus, err
 }
 
-func (c *nsxtClient) ListAllSections() ([]manager.FirewallSection, error) {
+func (c *nsxtClient) ListAllFirewallSections() ([]manager.FirewallSection, error) {
 	var firewallSections []manager.FirewallSection
 	var cursor string
 	for {
@@ -313,7 +313,7 @@ func (c *nsxtClient) ListAllSections() ([]manager.FirewallSection, error) {
 	return firewallSections, nil
 }
 
-func (c *nsxtClient) GetAllRules(sectionID string) ([]manager.FirewallRule, error) {
+func (c *nsxtClient) GetAllFirewallRules(sectionID string) ([]manager.FirewallRule, error) {
 	var firewallRules []manager.FirewallRule
 	var cursor string
 	for {

--- a/client/types.go
+++ b/client/types.go
@@ -69,3 +69,10 @@ type LoadBalancerClient interface {
 	ListAllLoadBalancers() ([]loadbalancer.LbService, error)
 	GetLoadBalancerStatus(loadBalancerID string) (loadbalancer.LbServiceStatus, error)
 }
+
+// FirewallClient represents Firewall sub-API group of Services for NSXT-T Client
+type FirewallClient interface {
+	ListAllSections() ([]manager.FirewallSection, error)
+	GetAllRules(sectionId string) ([]manager.FirewallRule, error)
+	GetFirewallStats(sectionId string, ruleId string) (manager.FirewallStats, error)
+}

--- a/client/types.go
+++ b/client/types.go
@@ -72,7 +72,7 @@ type LoadBalancerClient interface {
 
 // FirewallClient represents Firewall sub-API group of Services for NSXT-T Client
 type FirewallClient interface {
-	ListAllSections() ([]manager.FirewallSection, error)
-	GetAllRules(sectionId string) ([]manager.FirewallRule, error)
+	ListAllFirewallSections() ([]manager.FirewallSection, error)
+	GetAllFirewallRules(sectionId string) ([]manager.FirewallRule, error)
 	GetFirewallStats(sectionId string, ruleId string) (manager.FirewallStats, error)
 }

--- a/collector/firewall_collector.go
+++ b/collector/firewall_collector.go
@@ -1,0 +1,103 @@
+package collector
+
+import (
+	"nsxt_exporter/client"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	nsxt "github.com/vmware/go-vmware-nsxt"
+	"github.com/vmware/go-vmware-nsxt/manager"
+)
+
+func init() {
+	registerCollector("firewall", createFirewallCollectorFactory)
+}
+
+type firewallCollector struct {
+	firewallClient client.FirewallClient
+	logger         log.Logger
+
+	totalPackets *prometheus.Desc
+	totalBytes   *prometheus.Desc
+}
+
+type firewallStatisticMetric struct {
+	SectionID    string
+	RuleID       string
+	RuleName     string
+	TotalPackets float64
+	TotalBytes   float64
+}
+
+func createFirewallCollectorFactory(apiClient *nsxt.APIClient, logger log.Logger) prometheus.Collector {
+	nsxtClient := client.NewNSXTClient(apiClient, logger)
+	return newFirewallCollector(nsxtClient, logger)
+}
+
+func newFirewallCollector(firewallClient client.FirewallClient, logger log.Logger) *firewallCollector {
+	totalPackets := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "firewall", "total_packets"),
+		"Total packets processed by the firewall rule",
+		[]string{"id", "name", "section_id"},
+		nil,
+	)
+	totalBytes := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "firewall", "total_bytes"),
+		"Total bytes processed by the firewall rule",
+		[]string{"id", "name", "section_id"},
+		nil,
+	)
+	return &firewallCollector{
+		firewallClient: firewallClient,
+		logger:         logger,
+		totalPackets:   totalPackets,
+		totalBytes:     totalBytes,
+	}
+}
+
+// Describe implements the prometheus.Collector interface.
+func (c *firewallCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.totalPackets
+	ch <- c.totalBytes
+}
+
+// Collect implements the prometheus.Collector interface.
+func (c *firewallCollector) Collect(ch chan<- prometheus.Metric) {
+	firewallSections, err := c.firewallClient.ListAllSections()
+	if err != nil {
+		level.Error(c.logger).Log("msg", "Unable to list firewall sections", "err", err)
+	}
+	firewallStatisticMetrics := c.generateFirewallStatisticMetrics(firewallSections)
+	for _, m := range firewallStatisticMetrics {
+		labels := []string{m.RuleID, m.RuleName, m.SectionID}
+		ch <- prometheus.MustNewConstMetric(c.totalPackets, prometheus.GaugeValue, m.TotalPackets, labels...)
+		ch <- prometheus.MustNewConstMetric(c.totalBytes, prometheus.GaugeValue, m.TotalBytes, labels...)
+	}
+}
+
+func (c *firewallCollector) generateFirewallStatisticMetrics(firewallSections []manager.FirewallSection) (firewallStatisticMetrics []firewallStatisticMetric) {
+	for _, sec := range firewallSections {
+		rules, err := c.firewallClient.GetAllRules(sec.Id)
+		if err != nil {
+			level.Error(c.logger).Log("msg", "Unable to get firewall rules", "section", sec.Id, "err", err)
+			continue
+		}
+		for _, rule := range rules {
+			stats, err := c.firewallClient.GetFirewallStats(sec.Id, rule.Id)
+			if err != nil {
+				level.Error(c.logger).Log("msg", "Unable to get firewall statistic", "section", sec.Id, "rule", rule.Id, "err", err)
+				continue
+			}
+			firewallStatisticMetric := firewallStatisticMetric{
+				SectionID:    sec.Id,
+				RuleID:       rule.Id,
+				RuleName:     rule.DisplayName,
+				TotalPackets: float64(stats.PacketCount),
+				TotalBytes:   float64(stats.ByteCount),
+			}
+			firewallStatisticMetrics = append(firewallStatisticMetrics, firewallStatisticMetric)
+		}
+	}
+	return
+}

--- a/collector/firewall_collector.go
+++ b/collector/firewall_collector.go
@@ -64,7 +64,7 @@ func (c *firewallCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect implements the prometheus.Collector interface.
 func (c *firewallCollector) Collect(ch chan<- prometheus.Metric) {
-	firewallSections, err := c.firewallClient.ListAllSections()
+	firewallSections, err := c.firewallClient.ListAllFirewallSections()
 	if err != nil {
 		level.Error(c.logger).Log("msg", "Unable to list firewall sections", "err", err)
 	}
@@ -78,7 +78,7 @@ func (c *firewallCollector) Collect(ch chan<- prometheus.Metric) {
 
 func (c *firewallCollector) generateFirewallStatisticMetrics(firewallSections []manager.FirewallSection) (firewallStatisticMetrics []firewallStatisticMetric) {
 	for _, sec := range firewallSections {
-		rules, err := c.firewallClient.GetAllRules(sec.Id)
+		rules, err := c.firewallClient.GetAllFirewallRules(sec.Id)
 		if err != nil {
 			level.Error(c.logger).Log("msg", "Unable to get firewall rules", "section", sec.Id, "err", err)
 			continue

--- a/collector/firewall_collector_test.go
+++ b/collector/firewall_collector_test.go
@@ -30,11 +30,11 @@ type mockFirewallResponse struct {
 	Error      error
 }
 
-func (c *mockFirewallClient) ListAllSections() ([]manager.FirewallSection, error) {
+func (c *mockFirewallClient) ListAllFirewallSections() ([]manager.FirewallSection, error) {
 	panic("unused function. Only used to satisfy FirewallClient interface")
 }
 
-func (c *mockFirewallClient) GetAllRules(sectionID string) ([]manager.FirewallRule, error) {
+func (c *mockFirewallClient) GetAllFirewallRules(sectionID string) ([]manager.FirewallRule, error) {
 	if c.firewallRuleListError != nil {
 		return nil, c.firewallRuleListError
 	}

--- a/collector/firewall_collector_test.go
+++ b/collector/firewall_collector_test.go
@@ -1,0 +1,167 @@
+package collector
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/go-vmware-nsxt/manager"
+)
+
+const (
+	fakeFirewallSectionID        = "fake-firewall-section-id"
+	fakeFirewallRuleID           = "fake-firewall-rule-id"
+	fakeFirewallRuleName         = "fake-firewall-rule-name"
+	fakeFirewallRuleTotalPackets = 1
+	fakeFirewallRuleTotalBytes   = 1
+)
+
+type mockFirewallClient struct {
+	responses             []mockFirewallResponse
+	firewallRuleListError error
+}
+
+type mockFirewallResponse struct {
+	Section    manager.FirewallSection
+	Rules      []manager.FirewallRule
+	Statistics []manager.FirewallStats
+	Error      error
+}
+
+func (c *mockFirewallClient) ListAllSections() ([]manager.FirewallSection, error) {
+	panic("unused function. Only used to satisfy FirewallClient interface")
+}
+
+func (c *mockFirewallClient) GetAllRules(sectionID string) ([]manager.FirewallRule, error) {
+	if c.firewallRuleListError != nil {
+		return nil, c.firewallRuleListError
+	}
+	var firewallRules []manager.FirewallRule
+	for _, res := range c.responses {
+		if res.Section.Id != sectionID {
+			continue
+		}
+		for _, rule := range res.Rules {
+			firewallRule := manager.FirewallRule{
+				Id:          rule.Id,
+				DisplayName: rule.DisplayName,
+			}
+			firewallRules = append(firewallRules, firewallRule)
+		}
+	}
+	return firewallRules, nil
+}
+
+func (c *mockFirewallClient) GetFirewallStats(sectionID string, ruleID string) (manager.FirewallStats, error) {
+	for _, res := range c.responses {
+		if res.Section.Id != sectionID {
+			continue
+		}
+		for _, rule := range res.Rules {
+			if rule.Id != ruleID {
+				continue
+			}
+			return manager.FirewallStats{
+				RuleId:      ruleID,
+				PacketCount: fakeFirewallRuleTotalPackets,
+				ByteCount:   fakeFirewallRuleTotalBytes,
+			}, res.Error
+		}
+	}
+	return manager.FirewallStats{}, errors.New("error firewall rule not found")
+}
+
+func buildFirewallResponse(sectionID string, ruleIDs []string, err error) mockFirewallResponse {
+	var firewallRules []manager.FirewallRule
+	var firewallStatistics []manager.FirewallStats
+	for _, ruleID := range ruleIDs {
+		firewallRules = append(firewallRules, manager.FirewallRule{
+			Id:          fmt.Sprintf("%s-%s", fakeFirewallRuleID, ruleID),
+			DisplayName: fmt.Sprintf("%s-%s", fakeFirewallRuleName, ruleID),
+		})
+		firewallStatistics = append(firewallStatistics, manager.FirewallStats{
+			RuleId:      fmt.Sprintf("%s-%s", fakeFirewallRuleID, ruleID),
+			PacketCount: fakeFirewallRuleTotalPackets,
+			ByteCount:   fakeFirewallRuleTotalBytes,
+		})
+	}
+	return mockFirewallResponse{
+		Section: manager.FirewallSection{
+			Id: fmt.Sprintf("%s-%s", fakeFirewallSectionID, sectionID),
+		},
+		Rules:      firewallRules,
+		Statistics: firewallStatistics,
+		Error:      err,
+	}
+}
+
+func buildFirewallSections(firewallResponses []mockFirewallResponse) []manager.FirewallSection {
+	var firewallSections []manager.FirewallSection
+	for _, res := range firewallResponses {
+		firewallSections = append(firewallSections, res.Section)
+	}
+	return firewallSections
+}
+
+func TestFirewallCollector_GenerateFirewallStatisticMetrics(t *testing.T) {
+	testcases := []struct {
+		description           string
+		firewallRuleListError error
+		firewallResponses     []mockFirewallResponse
+		expectedMetrics       []firewallStatisticMetric
+	}{
+		{
+			description: "Should return correct statistics metrics",
+			firewallResponses: []mockFirewallResponse{
+				buildFirewallResponse("1", []string{"1", "2"}, nil),
+				buildFirewallResponse("2", []string{"3"}, nil),
+			},
+			expectedMetrics: []firewallStatisticMetric{
+				{
+					SectionID:    fmt.Sprintf("%s-1", fakeFirewallSectionID),
+					RuleID:       fmt.Sprintf("%s-1", fakeFirewallRuleID),
+					RuleName:     fmt.Sprintf("%s-1", fakeFirewallRuleName),
+					TotalPackets: fakeFirewallRuleTotalPackets,
+					TotalBytes:   fakeFirewallRuleTotalBytes,
+				},
+				{
+					SectionID:    fmt.Sprintf("%s-1", fakeFirewallSectionID),
+					RuleID:       fmt.Sprintf("%s-2", fakeFirewallRuleID),
+					RuleName:     fmt.Sprintf("%s-2", fakeFirewallRuleName),
+					TotalPackets: fakeFirewallRuleTotalPackets,
+					TotalBytes:   fakeFirewallRuleTotalBytes,
+				},
+				{
+					SectionID:    fmt.Sprintf("%s-2", fakeFirewallSectionID),
+					RuleID:       fmt.Sprintf("%s-3", fakeFirewallRuleID),
+					RuleName:     fmt.Sprintf("%s-3", fakeFirewallRuleName),
+					TotalPackets: fakeFirewallRuleTotalPackets,
+					TotalBytes:   fakeFirewallRuleTotalBytes,
+				},
+			},
+		},
+		{
+			description:       "Should return empty metrics when given empty firewall sections",
+			firewallResponses: []mockFirewallResponse{},
+			expectedMetrics:   []firewallStatisticMetric{},
+		},
+		{
+			description:           "Should return empty metrics when error listing nat rules",
+			firewallRuleListError: errors.New("error list firewall rules"),
+			firewallResponses:     []mockFirewallResponse{},
+			expectedMetrics:       []firewallStatisticMetric{},
+		},
+	}
+	for _, tc := range testcases {
+		mockFirewallClient := &mockFirewallClient{
+			responses: tc.firewallResponses,
+		}
+		logger := log.NewNopLogger()
+		firewallCollector := newFirewallCollector(mockFirewallClient, logger)
+		firewallSections := buildFirewallSections(tc.firewallResponses)
+		metrics := firewallCollector.generateFirewallStatisticMetrics(firewallSections)
+		assert.ElementsMatch(t, tc.expectedMetrics, metrics, tc.description)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/prometheus/client_golang v1.0.0
 	github.com/prometheus/common v0.9.1
 	github.com/stretchr/testify v1.4.0
-	github.com/vmware/go-vmware-nsxt v0.0.0-20200518150101-4d7ea459d1e7
+	github.com/vmware/go-vmware-nsxt v0.0.0-20200519214537-cf664f322b13
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 // indirect
 	golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.sum
+++ b/go.sum
@@ -64,12 +64,11 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/vmware/go-vmware-nsxt v0.0.0-20200518150101-4d7ea459d1e7 h1:8eZjoOTiSjhWgKrWhBDlbgIFodGlh2AT8RwGQ91UvwE=
-github.com/vmware/go-vmware-nsxt v0.0.0-20200518150101-4d7ea459d1e7/go.mod h1:VEqcmf4Sp7gPB7z05QGyKVmn6xWppr7Nz8cVNvyC80o=
+github.com/vmware/go-vmware-nsxt v0.0.0-20200519214537-cf664f322b13 h1:HzMUNxgHa/micvqIulRJwcUlu41oZtSCXasvKU2fvcM=
+github.com/vmware/go-vmware-nsxt v0.0.0-20200519214537-cf664f322b13/go.mod h1:VEqcmf4Sp7gPB7z05QGyKVmn6xWppr7Nz8cVNvyC80o=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
This collects firewall rule statistics by iterating
through firewall sections and rules. Metrics include
packets and bytes processed by each rule.

Signed-off-by: Giri Kuncoro <girikuncoro@gmail.com>