### PR TITLE
Change default port from 9732 to 9744

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ ARG ARCH="amd64"
 ARG OS="linux"
 COPY .build/${OS}-${ARCH}/nsxt_exporter /bin/nsxt_exporter
 
-EXPOSE      9732
+EXPOSE      9744
 USER        nobody
 ENTRYPOINT  [ "/bin/nsxt_exporter" ]

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ you can enable it using the `--nsxt.insecure=false` flag:
 To run the nsx-t exporter as a Docker container, run:
 
 ```bash
-docker run -p 9732:9732 cloudnativeid/nsxt-exporter-linux-amd64:latest --nsxt.host localhost --nsxt.username user --nsxt.password password
+docker run -p 9744:9744 cloudnativeid/nsxt-exporter-linux-amd64:latest --nsxt.host localhost --nsxt.username user --nsxt.password password
 ```
 
 ### Building

--- a/collector/load_balancer_collector_test.go
+++ b/collector/load_balancer_collector_test.go
@@ -15,7 +15,7 @@ const (
 	fakeLoadBalancerName           = "fake-load-balancer-name"
 	fakeLoadBalancerPoolID         = "fake-load-balancer-pool-id"
 	fakeLoadbalancerPoolMemberIP   = "127.0.0.1"
-	fakeLoadbalancerPoolMemberPort = "9732"
+	fakeLoadbalancerPoolMemberPort = "9744"
 )
 
 type mockLoadBalancerClient struct {

--- a/nsxt_exporter.go
+++ b/nsxt_exporter.go
@@ -39,7 +39,7 @@ func newNSXTClient(opts nsxtOpts) (*nsxt.APIClient, error) {
 
 func main() {
 	var (
-		listenAddress = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9732").String()
+		listenAddress = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9744").String()
 		metricsPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
 		opts          = nsxtOpts{}
 	)


### PR DESCRIPTION
Port 9732 has been reserved by other exporters, we have registered
nsxt exporter to the prometheus ports wiki page and have reserved
port 9744 as the default. Ref: https://github.com/prometheus/prometheus/wiki/Default-port-allocations

Signed-off-by: Giri Kuncoro <girikuncoro@gmail.com>