### PR TITLE
Restructure system metric status and refactor

### DIFF
--- a/collector/system_collector.go
+++ b/collector/system_collector.go
@@ -52,6 +52,11 @@ type systemStatusMetric struct {
 	DiskTotal                 map[string]float64
 }
 
+type serviceStatusMetric struct {
+	Name   string
+	Status float64
+}
+
 func createSystemCollectorFactory(apiClient *nsxt.APIClient, logger log.Logger) prometheus.Collector {
 	nsxtClient := client.NewNSXTClient(apiClient, logger)
 	return newSystemCollector(nsxtClient, logger)
@@ -280,8 +285,8 @@ func (sc *systemCollector) extractManagementNodeMetrics(managementNodes []admini
 	return
 }
 
-func (sc *systemCollector) collectServiceStatusMetrics() (systemStatusMetrics []systemStatusMetric) {
-	var collectors []func() (systemStatusMetric, error)
+func (sc *systemCollector) collectServiceStatusMetrics() (serviceStatusMetrics []serviceStatusMetric) {
+	var collectors []func() (serviceStatusMetric, error)
 	collectors = append(collectors, sc.collectApplianceServiceMetric)
 	collectors = append(collectors, sc.collectMessageBusServiceMetric)
 	collectors = append(collectors, sc.collectNTPServiceMetric)
@@ -300,17 +305,17 @@ func (sc *systemCollector) collectServiceStatusMetrics() (systemStatusMetrics []
 			level.Error(sc.logger).Log("msg", "Unable to collect system service status", "name", m.Name, "error", err.Error())
 			continue
 		}
-		systemStatusMetrics = append(systemStatusMetrics, m)
+		serviceStatusMetrics = append(serviceStatusMetrics, m)
 	}
 	return
 }
 
-func (sc *systemCollector) collectServiceStatusMetric(name string, collectSystemService func() (administration.NodeServiceStatusProperties, error)) (systemStatusMetric, error) {
+func (sc *systemCollector) collectServiceStatusMetric(name string, collectSystemService func() (administration.NodeServiceStatusProperties, error)) (serviceStatusMetric, error) {
 	status, err := collectSystemService()
 	if err != nil {
-		return systemStatusMetric{}, err
+		return serviceStatusMetric{}, err
 	}
-	statusMetric := systemStatusMetric{
+	statusMetric := serviceStatusMetric{
 		Name:   name,
 		Status: 0.0,
 	}
@@ -320,50 +325,50 @@ func (sc *systemCollector) collectServiceStatusMetric(name string, collectSystem
 	return statusMetric, nil
 }
 
-func (sc *systemCollector) collectApplianceServiceMetric() (systemStatusMetric, error) {
+func (sc *systemCollector) collectApplianceServiceMetric() (serviceStatusMetric, error) {
 	return sc.collectServiceStatusMetric("appliance", sc.systemClient.ReadApplianceManagementServiceStatus)
 }
 
-func (sc *systemCollector) collectMessageBusServiceMetric() (systemStatusMetric, error) {
+func (sc *systemCollector) collectMessageBusServiceMetric() (serviceStatusMetric, error) {
 	return sc.collectServiceStatusMetric("message_bus", sc.systemClient.ReadNSXMessageBusServiceStatus)
 }
 
-func (sc *systemCollector) collectNTPServiceMetric() (systemStatusMetric, error) {
+func (sc *systemCollector) collectNTPServiceMetric() (serviceStatusMetric, error) {
 	return sc.collectServiceStatusMetric("ntp", sc.systemClient.ReadNTPServiceStatus)
 }
 
-func (sc *systemCollector) collectUpgradeAgentServiceMetric() (systemStatusMetric, error) {
+func (sc *systemCollector) collectUpgradeAgentServiceMetric() (serviceStatusMetric, error) {
 	return sc.collectServiceStatusMetric("upgrade_agent", sc.systemClient.ReadNsxUpgradeAgentServiceStatus)
 }
 
-func (sc *systemCollector) collectProtonServiceMetric() (systemStatusMetric, error) {
+func (sc *systemCollector) collectProtonServiceMetric() (serviceStatusMetric, error) {
 	return sc.collectServiceStatusMetric("proton", sc.systemClient.ReadProtonServiceStatus)
 }
 
-func (sc *systemCollector) collectProxyServiceMetric() (systemStatusMetric, error) {
+func (sc *systemCollector) collectProxyServiceMetric() (serviceStatusMetric, error) {
 	return sc.collectServiceStatusMetric("proxy", sc.systemClient.ReadProxyServiceStatus)
 }
 
-func (sc *systemCollector) collectRabbitMQServiceMetric() (systemStatusMetric, error) {
+func (sc *systemCollector) collectRabbitMQServiceMetric() (serviceStatusMetric, error) {
 	return sc.collectServiceStatusMetric("rabbitmq", sc.systemClient.ReadRabbitMQServiceStatus)
 }
 
-func (sc *systemCollector) collectRepositoryServiceMetric() (systemStatusMetric, error) {
+func (sc *systemCollector) collectRepositoryServiceMetric() (serviceStatusMetric, error) {
 	return sc.collectServiceStatusMetric("repository", sc.systemClient.ReadRepositoryServiceStatus)
 }
 
-func (sc *systemCollector) collectSNMPServiceMetric() (systemStatusMetric, error) {
+func (sc *systemCollector) collectSNMPServiceMetric() (serviceStatusMetric, error) {
 	return sc.collectServiceStatusMetric("snmp", sc.systemClient.ReadSNMPServiceStatus)
 }
 
-func (sc *systemCollector) collectSSHServiceMetric() (systemStatusMetric, error) {
+func (sc *systemCollector) collectSSHServiceMetric() (serviceStatusMetric, error) {
 	return sc.collectServiceStatusMetric("ssh", sc.systemClient.ReadSSHServiceStatus)
 }
 
-func (sc *systemCollector) collectSearchServiceMetric() (systemStatusMetric, error) {
+func (sc *systemCollector) collectSearchServiceMetric() (serviceStatusMetric, error) {
 	return sc.collectServiceStatusMetric("search", sc.systemClient.ReadSearchServiceStatus)
 }
 
-func (sc *systemCollector) collectSyslogServiceMetric() (systemStatusMetric, error) {
+func (sc *systemCollector) collectSyslogServiceMetric() (serviceStatusMetric, error) {
 	return sc.collectServiceStatusMetric("syslog", sc.systemClient.ReadSyslogServiceStatus)
 }

--- a/collector/system_collector.go
+++ b/collector/system_collector.go
@@ -43,7 +43,6 @@ type clusterStatusMetric struct {
 type managementNodeMetric struct {
 	Name         string
 	IPAddress    string
-	Type         string
 	StatusDetail map[string]float64
 
 	CPUCores                  float64
@@ -273,7 +272,6 @@ func (sc *systemCollector) extractManagementNodeMetrics(managementNodes []admini
 	for _, m := range managementNodes {
 		managementNodeMetric := managementNodeMetric{
 			IPAddress:    m.RoleConfig.MgmtPlaneListenAddr.IpAddress,
-			Type:         "management",
 			StatusDetail: map[string]float64{},
 		}
 		for _, possibleStatus := range possibleNodeStatus {

--- a/collector/system_collector.go
+++ b/collector/system_collector.go
@@ -60,7 +60,6 @@ type managementNodeMetric struct {
 
 type controllerNodeStatusMetric struct {
 	IPAddress    string
-	Status       float64
 	StatusDetail map[string]float64
 }
 

--- a/collector/system_collector.go
+++ b/collector/system_collector.go
@@ -40,7 +40,7 @@ type clusterStatusMetric struct {
 	Status float64
 }
 
-type systemStatusMetric struct {
+type managementNodeMetric struct {
 	Name         string
 	IPAddress    string
 	Type         string
@@ -236,18 +236,15 @@ func (sc *systemCollector) collectClusterStatusMetrics() (clusterStatusMetrics [
 	return
 }
 
-func (sc *systemCollector) collectClusterNodeMetrics() (controllerNodeStatusMetrics []controllerNodeStatusMetric, systemStatusMetrics []systemStatusMetric) {
+func (sc *systemCollector) collectClusterNodeMetrics() (controllerNodeStatusMetrics []controllerNodeStatusMetric, managementNodeMetrics []managementNodeMetric) {
 	clusterNodes, err := sc.systemClient.ReadClusterNodesAggregateStatus()
 	if err != nil {
 		level.Error(sc.logger).Log("msg", "Unable to collect cluster nodes status")
 		return
 	}
 
-	controllerStatusMetrics := sc.extractControllerStatusMetrics(clusterNodes.ControllerCluster)
-	controllerNodeStatusMetrics = append(controllerNodeStatusMetrics, controllerStatusMetrics...)
-
-	managementNodeMetrics := sc.extractManagementNodeMetrics(clusterNodes.ManagementCluster)
-	systemStatusMetrics = append(systemStatusMetrics, managementNodeMetrics...)
+	controllerNodeStatusMetrics = sc.extractControllerStatusMetrics(clusterNodes.ControllerCluster)
+	managementNodeMetrics = sc.extractManagementNodeMetrics(clusterNodes.ManagementCluster)
 
 	return
 }
@@ -272,9 +269,9 @@ func (sc *systemCollector) extractControllerStatusMetrics(controllerNodes []admi
 	return
 }
 
-func (sc *systemCollector) extractManagementNodeMetrics(managementNodes []administration.ManagementNodeAggregateInfo) (systemStatusMetrics []systemStatusMetric) {
+func (sc *systemCollector) extractManagementNodeMetrics(managementNodes []administration.ManagementNodeAggregateInfo) (managementNodeMetrics []managementNodeMetric) {
 	for _, m := range managementNodes {
-		managementNodeMetric := systemStatusMetric{
+		managementNodeMetric := managementNodeMetric{
 			IPAddress:    m.RoleConfig.MgmtPlaneListenAddr.IpAddress,
 			Type:         "management",
 			StatusDetail: map[string]float64{},
@@ -309,7 +306,7 @@ func (sc *systemCollector) extractManagementNodeMetrics(managementNodes []admini
 				managementNodeMetric.DiskTotal[disk.Mount] = float64(disk.Total)
 			}
 		}
-		systemStatusMetrics = append(systemStatusMetrics, managementNodeMetric)
+		managementNodeMetrics = append(managementNodeMetrics, managementNodeMetric)
 	}
 	return
 }

--- a/collector/system_collector_test.go
+++ b/collector/system_collector_test.go
@@ -341,10 +341,10 @@ func TestSystemCollector_CollectClusterStatusMetrics(t *testing.T) {
 
 func TestSystemCollector_CollectClusterNodeMetrics(t *testing.T) {
 	testcases := []struct {
-		description               string
-		response                  mockClusterNodeStatusResponse
-		expectedControllerMetrics []controllerNodeStatusMetric
-		expectedMetrics           []managementNodeMetric
+		description                   string
+		response                      mockClusterNodeStatusResponse
+		expectedControllerMetrics     []controllerNodeStatusMetric
+		expectedManagementNodeMetrics []managementNodeMetric
 	}{
 		{
 			description: "Should return system metrics for management nodes and up value for connected nodes",
@@ -371,10 +371,9 @@ func TestSystemCollector_CollectClusterNodeMetrics(t *testing.T) {
 					StatusDetail: buildExpectedClusterNodeStatusDetail("CONNECTED"),
 				},
 			},
-			expectedMetrics: []managementNodeMetric{
+			expectedManagementNodeMetrics: []managementNodeMetric{
 				{
 					IPAddress:                 fakeClusterNodeIPAddress,
-					Type:                      "management",
 					StatusDetail:              buildExpectedClusterNodeStatusDetail("CONNECTED"),
 					CPUCores:                  fakeCPUCores,
 					LoadAverageOneMinute:      fakeLoadAverage,
@@ -394,7 +393,6 @@ func TestSystemCollector_CollectClusterNodeMetrics(t *testing.T) {
 				},
 				{
 					IPAddress:                 fakeClusterNodeIPAddress,
-					Type:                      "management",
 					StatusDetail:              buildExpectedClusterNodeStatusDetail("CONNECTED"),
 					CPUCores:                  fakeCPUCores,
 					LoadAverageOneMinute:      fakeLoadAverage,
@@ -453,10 +451,9 @@ func TestSystemCollector_CollectClusterNodeMetrics(t *testing.T) {
 					StatusDetail: buildExpectedClusterNodeStatusDetail("DISCONNECTED"),
 				},
 			},
-			expectedMetrics: []managementNodeMetric{
+			expectedManagementNodeMetrics: []managementNodeMetric{
 				{
 					IPAddress:                 fakeClusterNodeIPAddress,
-					Type:                      "management",
 					StatusDetail:              buildExpectedClusterNodeStatusDetail("DISCONNECTED"),
 					CPUCores:                  fakeCPUCores,
 					LoadAverageOneMinute:      fakeLoadAverage,
@@ -476,7 +473,6 @@ func TestSystemCollector_CollectClusterNodeMetrics(t *testing.T) {
 				},
 				{
 					IPAddress:                 fakeClusterNodeIPAddress,
-					Type:                      "management",
 					StatusDetail:              buildExpectedClusterNodeStatusDetail("UNKNOWN"),
 					CPUCores:                  fakeCPUCores,
 					LoadAverageOneMinute:      fakeLoadAverage,
@@ -508,7 +504,7 @@ func TestSystemCollector_CollectClusterNodeMetrics(t *testing.T) {
 				ManagementClusterStatus: []string{"CONNECTED"},
 				Error:                   errors.New("error read cluster node status"),
 			},
-			expectedMetrics: []managementNodeMetric{},
+			expectedManagementNodeMetrics: []managementNodeMetric{},
 		},
 	}
 	for _, tc := range testcases {
@@ -519,7 +515,7 @@ func TestSystemCollector_CollectClusterNodeMetrics(t *testing.T) {
 		systemCollector := newSystemCollector(mockSystemClient, logger)
 		controllerNodeMetrics, nodeMetrics := systemCollector.collectClusterNodeMetrics()
 		assert.ElementsMatch(t, tc.expectedControllerMetrics, controllerNodeMetrics, tc.description)
-		assert.ElementsMatch(t, tc.expectedMetrics, nodeMetrics, tc.description)
+		assert.ElementsMatch(t, tc.expectedManagementNodeMetrics, nodeMetrics, tc.description)
 	}
 }
 

--- a/collector/system_collector_test.go
+++ b/collector/system_collector_test.go
@@ -198,6 +198,16 @@ func buildExpectedServiceStatusDetail(nonZeroStatus string) map[string]float64 {
 	return statusDetails
 }
 
+func buildExpectedClusterNodeStatusDetail(nonZeroStatus string) map[string]float64 {
+	statusDetails := map[string]float64{
+		"CONNECTED":    0.0,
+		"DISCONNECTED": 0.0,
+		"UNKNOWN":      0.0,
+	}
+	statusDetails[nonZeroStatus] = 1.0
+	return statusDetails
+}
+
 func TestSystemCollector_CollectClusterStatusMetrics(t *testing.T) {
 	testcases := []struct {
 		description     string
@@ -354,18 +364,18 @@ func TestSystemCollector_CollectClusterNodeMetrics(t *testing.T) {
 			},
 			expectedControllerMetrics: []controllerNodeStatusMetric{
 				{
-					IPAddress: fakeClusterNodeIPAddress,
-					Status:    1.0,
+					IPAddress:    fakeClusterNodeIPAddress,
+					StatusDetail: buildExpectedClusterNodeStatusDetail("CONNECTED"),
 				}, {
-					IPAddress: fakeClusterNodeIPAddress,
-					Status:    1.0,
+					IPAddress:    fakeClusterNodeIPAddress,
+					StatusDetail: buildExpectedClusterNodeStatusDetail("CONNECTED"),
 				},
 			},
 			expectedMetrics: []systemStatusMetric{
 				{
 					IPAddress:                 fakeClusterNodeIPAddress,
 					Type:                      "management",
-					Status:                    1.0,
+					StatusDetail:              buildExpectedClusterNodeStatusDetail("CONNECTED"),
 					CPUCores:                  fakeCPUCores,
 					LoadAverageOneMinute:      fakeLoadAverage,
 					LoadAverageFiveMinutes:    fakeLoadAverage,
@@ -385,7 +395,7 @@ func TestSystemCollector_CollectClusterNodeMetrics(t *testing.T) {
 				{
 					IPAddress:                 fakeClusterNodeIPAddress,
 					Type:                      "management",
-					Status:                    1.0,
+					StatusDetail:              buildExpectedClusterNodeStatusDetail("CONNECTED"),
 					CPUCores:                  fakeCPUCores,
 					LoadAverageOneMinute:      fakeLoadAverage,
 					LoadAverageFiveMinutes:    fakeLoadAverage,
@@ -430,24 +440,24 @@ func TestSystemCollector_CollectClusterNodeMetrics(t *testing.T) {
 			},
 			expectedControllerMetrics: []controllerNodeStatusMetric{
 				{
-					IPAddress: fakeClusterNodeIPAddress,
-					Status:    0.0,
+					IPAddress:    fakeClusterNodeIPAddress,
+					StatusDetail: buildExpectedClusterNodeStatusDetail("DISCONNECTED"),
 				}, {
-					IPAddress: fakeClusterNodeIPAddress,
-					Status:    0.0,
+					IPAddress:    fakeClusterNodeIPAddress,
+					StatusDetail: buildExpectedClusterNodeStatusDetail("DISCONNECTED"),
 				}, {
-					IPAddress: fakeClusterNodeIPAddress,
-					Status:    0.0,
+					IPAddress:    fakeClusterNodeIPAddress,
+					StatusDetail: buildExpectedClusterNodeStatusDetail("DISCONNECTED"),
 				}, {
-					IPAddress: fakeClusterNodeIPAddress,
-					Status:    0.0,
+					IPAddress:    fakeClusterNodeIPAddress,
+					StatusDetail: buildExpectedClusterNodeStatusDetail("DISCONNECTED"),
 				},
 			},
 			expectedMetrics: []systemStatusMetric{
 				{
 					IPAddress:                 fakeClusterNodeIPAddress,
 					Type:                      "management",
-					Status:                    0.0,
+					StatusDetail:              buildExpectedClusterNodeStatusDetail("DISCONNECTED"),
 					CPUCores:                  fakeCPUCores,
 					LoadAverageOneMinute:      fakeLoadAverage,
 					LoadAverageFiveMinutes:    fakeLoadAverage,
@@ -467,7 +477,7 @@ func TestSystemCollector_CollectClusterNodeMetrics(t *testing.T) {
 				{
 					IPAddress:                 fakeClusterNodeIPAddress,
 					Type:                      "management",
-					Status:                    0.0,
+					StatusDetail:              buildExpectedClusterNodeStatusDetail("UNKNOWN"),
 					CPUCores:                  fakeCPUCores,
 					LoadAverageOneMinute:      fakeLoadAverage,
 					LoadAverageFiveMinutes:    fakeLoadAverage,

--- a/collector/system_collector_test.go
+++ b/collector/system_collector_test.go
@@ -189,6 +189,15 @@ func (c *mockSystemClient) ReadSyslogServiceStatus() (administration.NodeService
 	return c.buildServiceStatusResponse()
 }
 
+func buildExpectedServiceStatusDetail(nonZeroStatus string) map[string]float64 {
+	statusDetails := map[string]float64{
+		"RUNNING": 0.0,
+		"STOPPED": 0.0,
+	}
+	statusDetails[nonZeroStatus] = 1.0
+	return statusDetails
+}
+
 func TestSystemCollector_CollectClusterStatusMetrics(t *testing.T) {
 	testcases := []struct {
 		description     string
@@ -517,17 +526,17 @@ func TestSystemCollector_CollectApplianceServiceMetric(t *testing.T) {
 		{
 			description:    "Should return up value when appliance service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: serviceStatusMetric{Name: "appliance", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "appliance", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return up value when appliance service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: serviceStatusMetric{Name: "appliance", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "appliance", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return down value when appliance service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: serviceStatusMetric{Name: "appliance", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "appliance", StatusDetail: buildExpectedServiceStatusDetail("STOPPED")},
 		},
 		{
 			description:    "Should return empty when failed reading appliance service state",
@@ -558,17 +567,17 @@ func TestSystemCollector_CollectMessageBusServiceMetric(t *testing.T) {
 		{
 			description:    "Should return up value when message bus service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: serviceStatusMetric{Name: "message_bus", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "message_bus", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return up value when message bus service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: serviceStatusMetric{Name: "message_bus", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "message_bus", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return down value when message bus service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: serviceStatusMetric{Name: "message_bus", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "message_bus", StatusDetail: buildExpectedServiceStatusDetail("STOPPED")},
 		},
 		{
 			description:    "Should return empty when failed reading message bus service state",
@@ -599,17 +608,17 @@ func TestSystemCollector_CollectNTPServiceMetric(t *testing.T) {
 		{
 			description:    "Should return up value when ntp service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: serviceStatusMetric{Name: "ntp", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "ntp", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return up value when ntp service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: serviceStatusMetric{Name: "ntp", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "ntp", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return down value when ntp service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: serviceStatusMetric{Name: "ntp", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "ntp", StatusDetail: buildExpectedServiceStatusDetail("STOPPED")},
 		},
 		{
 			description:    "Should return empty when failed reading ntp service state",
@@ -640,17 +649,17 @@ func TestSystemCollector_CollectUpgradeServiceMetric(t *testing.T) {
 		{
 			description:    "Should return up value when upgrade agent service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: serviceStatusMetric{Name: "upgrade_agent", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "upgrade_agent", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return up value when upgrade agent service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: serviceStatusMetric{Name: "upgrade_agent", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "upgrade_agent", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return down value when upgrade agent service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: serviceStatusMetric{Name: "upgrade_agent", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "upgrade_agent", StatusDetail: buildExpectedServiceStatusDetail("STOPPED")},
 		},
 		{
 			description:    "Should return empty when failed reading upgrade agent service state",
@@ -681,17 +690,17 @@ func TestSystemCollector_CollectProtonServiceMetric(t *testing.T) {
 		{
 			description:    "Should return up value when proton service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: serviceStatusMetric{Name: "proton", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "proton", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return up value when proton service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: serviceStatusMetric{Name: "proton", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "proton", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return down value when proton service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: serviceStatusMetric{Name: "proton", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "proton", StatusDetail: buildExpectedServiceStatusDetail("STOPPED")},
 		},
 		{
 			description:    "Should return empty when failed reading proton service state",
@@ -722,17 +731,17 @@ func TestSystemCollector_CollectProxyServiceMetric(t *testing.T) {
 		{
 			description:    "Should return up value when proxy service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: serviceStatusMetric{Name: "proxy", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "proxy", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return up value when proxy service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: serviceStatusMetric{Name: "proxy", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "proxy", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return down value when proxy service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: serviceStatusMetric{Name: "proxy", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "proxy", StatusDetail: buildExpectedServiceStatusDetail("STOPPED")},
 		},
 		{
 			description:    "Should return empty when failed reading proxy service state",
@@ -763,17 +772,17 @@ func TestSystemCollector_CollectRabbitMQServiceMetric(t *testing.T) {
 		{
 			description:    "Should return up value when rabbitmq service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: serviceStatusMetric{Name: "rabbitmq", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "rabbitmq", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return up value when rabbitmq service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: serviceStatusMetric{Name: "rabbitmq", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "rabbitmq", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return down value when rabbitmq service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: serviceStatusMetric{Name: "rabbitmq", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "rabbitmq", StatusDetail: buildExpectedServiceStatusDetail("STOPPED")},
 		},
 		{
 			description:    "Should return empty when failed reading rabbitmq service state",
@@ -804,17 +813,17 @@ func TestSystemCollector_CollectRepositoryServiceMetric(t *testing.T) {
 		{
 			description:    "Should return up value when repository service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: serviceStatusMetric{Name: "repository", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "repository", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return up value when repository service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: serviceStatusMetric{Name: "repository", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "repository", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return down value when repository service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: serviceStatusMetric{Name: "repository", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "repository", StatusDetail: buildExpectedServiceStatusDetail("STOPPED")},
 		},
 		{
 			description:    "Should return empty when failed reading repository service state",
@@ -845,17 +854,17 @@ func TestSystemCollector_CollectSNMPServiceMetric(t *testing.T) {
 		{
 			description:    "Should return up value when snmp service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: serviceStatusMetric{Name: "snmp", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "snmp", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return up value when snmp service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: serviceStatusMetric{Name: "snmp", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "snmp", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return down value when snmp service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: serviceStatusMetric{Name: "snmp", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "snmp", StatusDetail: buildExpectedServiceStatusDetail("STOPPED")},
 		},
 		{
 			description:    "Should return empty when failed reading snmp service state",
@@ -886,17 +895,17 @@ func TestSystemCollector_CollectSSHServiceMetric(t *testing.T) {
 		{
 			description:    "Should return up value when ssh service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: serviceStatusMetric{Name: "ssh", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "ssh", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return up value when ssh service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: serviceStatusMetric{Name: "ssh", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "ssh", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return down value when ssh service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: serviceStatusMetric{Name: "ssh", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "ssh", StatusDetail: buildExpectedServiceStatusDetail("STOPPED")},
 		},
 		{
 			description:    "Should return empty when failed reading ssh service state",
@@ -927,17 +936,17 @@ func TestSystemCollector_CollectSearchServiceMetric(t *testing.T) {
 		{
 			description:    "Should return up value when search service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: serviceStatusMetric{Name: "search", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "search", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return up value when search service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: serviceStatusMetric{Name: "search", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "search", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return down value when search service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: serviceStatusMetric{Name: "search", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "search", StatusDetail: buildExpectedServiceStatusDetail("STOPPED")},
 		},
 		{
 			description:    "Should return empty when failed reading search service state",
@@ -968,17 +977,17 @@ func TestSystemCollector_CollectSyslogServiceMetric(t *testing.T) {
 		{
 			description:    "Should return up value when syslog service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: serviceStatusMetric{Name: "syslog", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "syslog", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return up value when syslog service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: serviceStatusMetric{Name: "syslog", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "syslog", StatusDetail: buildExpectedServiceStatusDetail("RUNNING")},
 		},
 		{
 			description:    "Should return down value when syslog service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: serviceStatusMetric{Name: "syslog", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "syslog", StatusDetail: buildExpectedServiceStatusDetail("STOPPED")},
 		},
 		{
 			description:    "Should return empty when failed reading syslog service state",

--- a/collector/system_collector_test.go
+++ b/collector/system_collector_test.go
@@ -344,7 +344,7 @@ func TestSystemCollector_CollectClusterNodeMetrics(t *testing.T) {
 		description               string
 		response                  mockClusterNodeStatusResponse
 		expectedControllerMetrics []controllerNodeStatusMetric
-		expectedMetrics           []systemStatusMetric
+		expectedMetrics           []managementNodeMetric
 	}{
 		{
 			description: "Should return system metrics for management nodes and up value for connected nodes",
@@ -371,7 +371,7 @@ func TestSystemCollector_CollectClusterNodeMetrics(t *testing.T) {
 					StatusDetail: buildExpectedClusterNodeStatusDetail("CONNECTED"),
 				},
 			},
-			expectedMetrics: []systemStatusMetric{
+			expectedMetrics: []managementNodeMetric{
 				{
 					IPAddress:                 fakeClusterNodeIPAddress,
 					Type:                      "management",
@@ -453,7 +453,7 @@ func TestSystemCollector_CollectClusterNodeMetrics(t *testing.T) {
 					StatusDetail: buildExpectedClusterNodeStatusDetail("DISCONNECTED"),
 				},
 			},
-			expectedMetrics: []systemStatusMetric{
+			expectedMetrics: []managementNodeMetric{
 				{
 					IPAddress:                 fakeClusterNodeIPAddress,
 					Type:                      "management",
@@ -508,7 +508,7 @@ func TestSystemCollector_CollectClusterNodeMetrics(t *testing.T) {
 				ManagementClusterStatus: []string{"CONNECTED"},
 				Error:                   errors.New("error read cluster node status"),
 			},
-			expectedMetrics: []systemStatusMetric{},
+			expectedMetrics: []managementNodeMetric{},
 		},
 	}
 	for _, tc := range testcases {

--- a/collector/system_collector_test.go
+++ b/collector/system_collector_test.go
@@ -512,27 +512,27 @@ func TestSystemCollector_CollectApplianceServiceMetric(t *testing.T) {
 	testcases := []struct {
 		description    string
 		response       mockClusterServiceStatusResponse
-		expectedMetric systemStatusMetric
+		expectedMetric serviceStatusMetric
 	}{
 		{
 			description:    "Should return up value when appliance service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: systemStatusMetric{Name: "appliance", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "appliance", Status: 1.0},
 		},
 		{
 			description:    "Should return up value when appliance service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: systemStatusMetric{Name: "appliance", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "appliance", Status: 1.0},
 		},
 		{
 			description:    "Should return down value when appliance service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: systemStatusMetric{Name: "appliance", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "appliance", Status: 0.0},
 		},
 		{
 			description:    "Should return empty when failed reading appliance service state",
 			response:       mockClusterServiceStatusResponse{"RUNNING", errors.New("error read state")},
-			expectedMetric: systemStatusMetric{},
+			expectedMetric: serviceStatusMetric{},
 		},
 	}
 	for _, tc := range testcases {
@@ -543,7 +543,7 @@ func TestSystemCollector_CollectApplianceServiceMetric(t *testing.T) {
 		systemCollector := newSystemCollector(mockSystemClient, logger)
 		serviceMetric, err := systemCollector.collectApplianceServiceMetric()
 		assert.Equal(t, tc.expectedMetric, serviceMetric, tc.description)
-		if reflect.DeepEqual(tc.expectedMetric, (systemStatusMetric{})) {
+		if reflect.DeepEqual(tc.expectedMetric, serviceStatusMetric{}) {
 			assert.Error(t, err)
 		}
 	}
@@ -553,27 +553,27 @@ func TestSystemCollector_CollectMessageBusServiceMetric(t *testing.T) {
 	testcases := []struct {
 		description    string
 		response       mockClusterServiceStatusResponse
-		expectedMetric systemStatusMetric
+		expectedMetric serviceStatusMetric
 	}{
 		{
 			description:    "Should return up value when message bus service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: systemStatusMetric{Name: "message_bus", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "message_bus", Status: 1.0},
 		},
 		{
 			description:    "Should return up value when message bus service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: systemStatusMetric{Name: "message_bus", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "message_bus", Status: 1.0},
 		},
 		{
 			description:    "Should return down value when message bus service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: systemStatusMetric{Name: "message_bus", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "message_bus", Status: 0.0},
 		},
 		{
 			description:    "Should return empty when failed reading message bus service state",
 			response:       mockClusterServiceStatusResponse{"RUNNING", errors.New("error read state")},
-			expectedMetric: systemStatusMetric{},
+			expectedMetric: serviceStatusMetric{},
 		},
 	}
 	for _, tc := range testcases {
@@ -584,7 +584,7 @@ func TestSystemCollector_CollectMessageBusServiceMetric(t *testing.T) {
 		systemCollector := newSystemCollector(mockSystemClient, logger)
 		serviceMetric, err := systemCollector.collectMessageBusServiceMetric()
 		assert.Equal(t, tc.expectedMetric, serviceMetric, tc.description)
-		if reflect.DeepEqual(tc.expectedMetric, (systemStatusMetric{})) {
+		if reflect.DeepEqual(tc.expectedMetric, serviceStatusMetric{}) {
 			assert.Error(t, err)
 		}
 	}
@@ -594,27 +594,27 @@ func TestSystemCollector_CollectNTPServiceMetric(t *testing.T) {
 	testcases := []struct {
 		description    string
 		response       mockClusterServiceStatusResponse
-		expectedMetric systemStatusMetric
+		expectedMetric serviceStatusMetric
 	}{
 		{
 			description:    "Should return up value when ntp service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: systemStatusMetric{Name: "ntp", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "ntp", Status: 1.0},
 		},
 		{
 			description:    "Should return up value when ntp service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: systemStatusMetric{Name: "ntp", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "ntp", Status: 1.0},
 		},
 		{
 			description:    "Should return down value when ntp service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: systemStatusMetric{Name: "ntp", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "ntp", Status: 0.0},
 		},
 		{
 			description:    "Should return empty when failed reading ntp service state",
 			response:       mockClusterServiceStatusResponse{"RUNNING", errors.New("error read state")},
-			expectedMetric: systemStatusMetric{},
+			expectedMetric: serviceStatusMetric{},
 		},
 	}
 	for _, tc := range testcases {
@@ -625,7 +625,7 @@ func TestSystemCollector_CollectNTPServiceMetric(t *testing.T) {
 		systemCollector := newSystemCollector(mockSystemClient, logger)
 		serviceMetric, err := systemCollector.collectNTPServiceMetric()
 		assert.Equal(t, tc.expectedMetric, serviceMetric, tc.description)
-		if reflect.DeepEqual(tc.expectedMetric, (systemStatusMetric{})) {
+		if reflect.DeepEqual(tc.expectedMetric, serviceStatusMetric{}) {
 			assert.Error(t, err)
 		}
 	}
@@ -635,27 +635,27 @@ func TestSystemCollector_CollectUpgradeServiceMetric(t *testing.T) {
 	testcases := []struct {
 		description    string
 		response       mockClusterServiceStatusResponse
-		expectedMetric systemStatusMetric
+		expectedMetric serviceStatusMetric
 	}{
 		{
 			description:    "Should return up value when upgrade agent service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: systemStatusMetric{Name: "upgrade_agent", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "upgrade_agent", Status: 1.0},
 		},
 		{
 			description:    "Should return up value when upgrade agent service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: systemStatusMetric{Name: "upgrade_agent", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "upgrade_agent", Status: 1.0},
 		},
 		{
 			description:    "Should return down value when upgrade agent service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: systemStatusMetric{Name: "upgrade_agent", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "upgrade_agent", Status: 0.0},
 		},
 		{
 			description:    "Should return empty when failed reading upgrade agent service state",
 			response:       mockClusterServiceStatusResponse{"RUNNING", errors.New("error read state")},
-			expectedMetric: systemStatusMetric{},
+			expectedMetric: serviceStatusMetric{},
 		},
 	}
 	for _, tc := range testcases {
@@ -666,7 +666,7 @@ func TestSystemCollector_CollectUpgradeServiceMetric(t *testing.T) {
 		systemCollector := newSystemCollector(mockSystemClient, logger)
 		serviceMetric, err := systemCollector.collectUpgradeAgentServiceMetric()
 		assert.Equal(t, tc.expectedMetric, serviceMetric, tc.description)
-		if reflect.DeepEqual(tc.expectedMetric, (systemStatusMetric{})) {
+		if reflect.DeepEqual(tc.expectedMetric, serviceStatusMetric{}) {
 			assert.Error(t, err)
 		}
 	}
@@ -676,27 +676,27 @@ func TestSystemCollector_CollectProtonServiceMetric(t *testing.T) {
 	testcases := []struct {
 		description    string
 		response       mockClusterServiceStatusResponse
-		expectedMetric systemStatusMetric
+		expectedMetric serviceStatusMetric
 	}{
 		{
 			description:    "Should return up value when proton service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: systemStatusMetric{Name: "proton", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "proton", Status: 1.0},
 		},
 		{
 			description:    "Should return up value when proton service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: systemStatusMetric{Name: "proton", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "proton", Status: 1.0},
 		},
 		{
 			description:    "Should return down value when proton service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: systemStatusMetric{Name: "proton", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "proton", Status: 0.0},
 		},
 		{
 			description:    "Should return empty when failed reading proton service state",
 			response:       mockClusterServiceStatusResponse{"RUNNING", errors.New("error read state")},
-			expectedMetric: systemStatusMetric{},
+			expectedMetric: serviceStatusMetric{},
 		},
 	}
 	for _, tc := range testcases {
@@ -707,7 +707,7 @@ func TestSystemCollector_CollectProtonServiceMetric(t *testing.T) {
 		systemCollector := newSystemCollector(mockSystemClient, logger)
 		serviceMetric, err := systemCollector.collectProtonServiceMetric()
 		assert.Equal(t, tc.expectedMetric, serviceMetric, tc.description)
-		if reflect.DeepEqual(tc.expectedMetric, (systemStatusMetric{})) {
+		if reflect.DeepEqual(tc.expectedMetric, serviceStatusMetric{}) {
 			assert.Error(t, err)
 		}
 	}
@@ -717,27 +717,27 @@ func TestSystemCollector_CollectProxyServiceMetric(t *testing.T) {
 	testcases := []struct {
 		description    string
 		response       mockClusterServiceStatusResponse
-		expectedMetric systemStatusMetric
+		expectedMetric serviceStatusMetric
 	}{
 		{
 			description:    "Should return up value when proxy service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: systemStatusMetric{Name: "proxy", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "proxy", Status: 1.0},
 		},
 		{
 			description:    "Should return up value when proxy service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: systemStatusMetric{Name: "proxy", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "proxy", Status: 1.0},
 		},
 		{
 			description:    "Should return down value when proxy service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: systemStatusMetric{Name: "proxy", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "proxy", Status: 0.0},
 		},
 		{
 			description:    "Should return empty when failed reading proxy service state",
 			response:       mockClusterServiceStatusResponse{"RUNNING", errors.New("error read state")},
-			expectedMetric: systemStatusMetric{},
+			expectedMetric: serviceStatusMetric{},
 		},
 	}
 	for _, tc := range testcases {
@@ -748,7 +748,7 @@ func TestSystemCollector_CollectProxyServiceMetric(t *testing.T) {
 		systemCollector := newSystemCollector(mockSystemClient, logger)
 		serviceMetric, err := systemCollector.collectProxyServiceMetric()
 		assert.Equal(t, tc.expectedMetric, serviceMetric, tc.description)
-		if reflect.DeepEqual(tc.expectedMetric, (systemStatusMetric{})) {
+		if reflect.DeepEqual(tc.expectedMetric, serviceStatusMetric{}) {
 			assert.Error(t, err)
 		}
 	}
@@ -758,27 +758,27 @@ func TestSystemCollector_CollectRabbitMQServiceMetric(t *testing.T) {
 	testcases := []struct {
 		description    string
 		response       mockClusterServiceStatusResponse
-		expectedMetric systemStatusMetric
+		expectedMetric serviceStatusMetric
 	}{
 		{
 			description:    "Should return up value when rabbitmq service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: systemStatusMetric{Name: "rabbitmq", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "rabbitmq", Status: 1.0},
 		},
 		{
 			description:    "Should return up value when rabbitmq service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: systemStatusMetric{Name: "rabbitmq", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "rabbitmq", Status: 1.0},
 		},
 		{
 			description:    "Should return down value when rabbitmq service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: systemStatusMetric{Name: "rabbitmq", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "rabbitmq", Status: 0.0},
 		},
 		{
 			description:    "Should return empty when failed reading rabbitmq service state",
 			response:       mockClusterServiceStatusResponse{"RUNNING", errors.New("error read state")},
-			expectedMetric: systemStatusMetric{},
+			expectedMetric: serviceStatusMetric{},
 		},
 	}
 	for _, tc := range testcases {
@@ -789,7 +789,7 @@ func TestSystemCollector_CollectRabbitMQServiceMetric(t *testing.T) {
 		systemCollector := newSystemCollector(mockSystemClient, logger)
 		serviceMetric, err := systemCollector.collectRabbitMQServiceMetric()
 		assert.Equal(t, tc.expectedMetric, serviceMetric, tc.description)
-		if reflect.DeepEqual(tc.expectedMetric, (systemStatusMetric{})) {
+		if reflect.DeepEqual(tc.expectedMetric, serviceStatusMetric{}) {
 			assert.Error(t, err)
 		}
 	}
@@ -799,27 +799,27 @@ func TestSystemCollector_CollectRepositoryServiceMetric(t *testing.T) {
 	testcases := []struct {
 		description    string
 		response       mockClusterServiceStatusResponse
-		expectedMetric systemStatusMetric
+		expectedMetric serviceStatusMetric
 	}{
 		{
 			description:    "Should return up value when repository service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: systemStatusMetric{Name: "repository", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "repository", Status: 1.0},
 		},
 		{
 			description:    "Should return up value when repository service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: systemStatusMetric{Name: "repository", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "repository", Status: 1.0},
 		},
 		{
 			description:    "Should return down value when repository service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: systemStatusMetric{Name: "repository", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "repository", Status: 0.0},
 		},
 		{
 			description:    "Should return empty when failed reading repository service state",
 			response:       mockClusterServiceStatusResponse{"RUNNING", errors.New("error read state")},
-			expectedMetric: systemStatusMetric{},
+			expectedMetric: serviceStatusMetric{},
 		},
 	}
 	for _, tc := range testcases {
@@ -830,7 +830,7 @@ func TestSystemCollector_CollectRepositoryServiceMetric(t *testing.T) {
 		systemCollector := newSystemCollector(mockSystemClient, logger)
 		serviceMetric, err := systemCollector.collectRepositoryServiceMetric()
 		assert.Equal(t, tc.expectedMetric, serviceMetric, tc.description)
-		if reflect.DeepEqual(tc.expectedMetric, (systemStatusMetric{})) {
+		if reflect.DeepEqual(tc.expectedMetric, serviceStatusMetric{}) {
 			assert.Error(t, err)
 		}
 	}
@@ -840,27 +840,27 @@ func TestSystemCollector_CollectSNMPServiceMetric(t *testing.T) {
 	testcases := []struct {
 		description    string
 		response       mockClusterServiceStatusResponse
-		expectedMetric systemStatusMetric
+		expectedMetric serviceStatusMetric
 	}{
 		{
 			description:    "Should return up value when snmp service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: systemStatusMetric{Name: "snmp", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "snmp", Status: 1.0},
 		},
 		{
 			description:    "Should return up value when snmp service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: systemStatusMetric{Name: "snmp", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "snmp", Status: 1.0},
 		},
 		{
 			description:    "Should return down value when snmp service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: systemStatusMetric{Name: "snmp", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "snmp", Status: 0.0},
 		},
 		{
 			description:    "Should return empty when failed reading snmp service state",
 			response:       mockClusterServiceStatusResponse{"RUNNING", errors.New("error read state")},
-			expectedMetric: systemStatusMetric{},
+			expectedMetric: serviceStatusMetric{},
 		},
 	}
 	for _, tc := range testcases {
@@ -871,7 +871,7 @@ func TestSystemCollector_CollectSNMPServiceMetric(t *testing.T) {
 		systemCollector := newSystemCollector(mockSystemClient, logger)
 		serviceMetric, err := systemCollector.collectSNMPServiceMetric()
 		assert.Equal(t, tc.expectedMetric, serviceMetric, tc.description)
-		if reflect.DeepEqual(tc.expectedMetric, (systemStatusMetric{})) {
+		if reflect.DeepEqual(tc.expectedMetric, serviceStatusMetric{}) {
 			assert.Error(t, err)
 		}
 	}
@@ -881,27 +881,27 @@ func TestSystemCollector_CollectSSHServiceMetric(t *testing.T) {
 	testcases := []struct {
 		description    string
 		response       mockClusterServiceStatusResponse
-		expectedMetric systemStatusMetric
+		expectedMetric serviceStatusMetric
 	}{
 		{
 			description:    "Should return up value when ssh service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: systemStatusMetric{Name: "ssh", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "ssh", Status: 1.0},
 		},
 		{
 			description:    "Should return up value when ssh service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: systemStatusMetric{Name: "ssh", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "ssh", Status: 1.0},
 		},
 		{
 			description:    "Should return down value when ssh service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: systemStatusMetric{Name: "ssh", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "ssh", Status: 0.0},
 		},
 		{
 			description:    "Should return empty when failed reading ssh service state",
 			response:       mockClusterServiceStatusResponse{"RUNNING", errors.New("error read state")},
-			expectedMetric: systemStatusMetric{},
+			expectedMetric: serviceStatusMetric{},
 		},
 	}
 	for _, tc := range testcases {
@@ -912,7 +912,7 @@ func TestSystemCollector_CollectSSHServiceMetric(t *testing.T) {
 		systemCollector := newSystemCollector(mockSystemClient, logger)
 		serviceMetric, err := systemCollector.collectSSHServiceMetric()
 		assert.Equal(t, tc.expectedMetric, serviceMetric, tc.description)
-		if reflect.DeepEqual(tc.expectedMetric, (systemStatusMetric{})) {
+		if reflect.DeepEqual(tc.expectedMetric, serviceStatusMetric{}) {
 			assert.Error(t, err)
 		}
 	}
@@ -922,27 +922,27 @@ func TestSystemCollector_CollectSearchServiceMetric(t *testing.T) {
 	testcases := []struct {
 		description    string
 		response       mockClusterServiceStatusResponse
-		expectedMetric systemStatusMetric
+		expectedMetric serviceStatusMetric
 	}{
 		{
 			description:    "Should return up value when search service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: systemStatusMetric{Name: "search", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "search", Status: 1.0},
 		},
 		{
 			description:    "Should return up value when search service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: systemStatusMetric{Name: "search", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "search", Status: 1.0},
 		},
 		{
 			description:    "Should return down value when search service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: systemStatusMetric{Name: "search", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "search", Status: 0.0},
 		},
 		{
 			description:    "Should return empty when failed reading search service state",
 			response:       mockClusterServiceStatusResponse{"RUNNING", errors.New("error read state")},
-			expectedMetric: systemStatusMetric{},
+			expectedMetric: serviceStatusMetric{},
 		},
 	}
 	for _, tc := range testcases {
@@ -953,7 +953,7 @@ func TestSystemCollector_CollectSearchServiceMetric(t *testing.T) {
 		systemCollector := newSystemCollector(mockSystemClient, logger)
 		serviceMetric, err := systemCollector.collectSearchServiceMetric()
 		assert.Equal(t, tc.expectedMetric, serviceMetric, tc.description)
-		if reflect.DeepEqual(tc.expectedMetric, (systemStatusMetric{})) {
+		if reflect.DeepEqual(tc.expectedMetric, serviceStatusMetric{}) {
 			assert.Error(t, err)
 		}
 	}
@@ -963,27 +963,27 @@ func TestSystemCollector_CollectSyslogServiceMetric(t *testing.T) {
 	testcases := []struct {
 		description    string
 		response       mockClusterServiceStatusResponse
-		expectedMetric systemStatusMetric
+		expectedMetric serviceStatusMetric
 	}{
 		{
 			description:    "Should return up value when syslog service is running",
 			response:       mockClusterServiceStatusResponse{"RUNNING", nil},
-			expectedMetric: systemStatusMetric{Name: "syslog", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "syslog", Status: 1.0},
 		},
 		{
 			description:    "Should return up value when syslog service is running with mixed cases",
 			response:       mockClusterServiceStatusResponse{"Running", nil},
-			expectedMetric: systemStatusMetric{Name: "syslog", Status: 1.0},
+			expectedMetric: serviceStatusMetric{Name: "syslog", Status: 1.0},
 		},
 		{
 			description:    "Should return down value when syslog service is not running",
 			response:       mockClusterServiceStatusResponse{"STOPPED", nil},
-			expectedMetric: systemStatusMetric{Name: "syslog", Status: 0.0},
+			expectedMetric: serviceStatusMetric{Name: "syslog", Status: 0.0},
 		},
 		{
 			description:    "Should return empty when failed reading syslog service state",
 			response:       mockClusterServiceStatusResponse{"RUNNING", errors.New("error read state")},
-			expectedMetric: systemStatusMetric{},
+			expectedMetric: serviceStatusMetric{},
 		},
 	}
 	for _, tc := range testcases {
@@ -994,7 +994,7 @@ func TestSystemCollector_CollectSyslogServiceMetric(t *testing.T) {
 		systemCollector := newSystemCollector(mockSystemClient, logger)
 		serviceMetric, err := systemCollector.collectSyslogServiceMetric()
 		assert.Equal(t, tc.expectedMetric, serviceMetric, tc.description)
-		if reflect.DeepEqual(tc.expectedMetric, (systemStatusMetric{})) {
+		if reflect.DeepEqual(tc.expectedMetric, serviceStatusMetric{}) {
 			assert.Error(t, err)
 		}
 	}

--- a/collector/system_collector_test.go
+++ b/collector/system_collector_test.go
@@ -212,7 +212,7 @@ func TestSystemCollector_CollectClusterStatusMetrics(t *testing.T) {
 	testcases := []struct {
 		description     string
 		response        mockClusterStatusResponse
-		expectedMetrics []systemStatusMetric
+		expectedMetrics []clusterStatusMetric
 	}{
 		{
 			description: "Should return up value when both controller and management stable",
@@ -221,7 +221,7 @@ func TestSystemCollector_CollectClusterStatusMetrics(t *testing.T) {
 				ManagementStatus: "STABLE",
 				Error:            nil,
 			},
-			expectedMetrics: []systemStatusMetric{
+			expectedMetrics: []clusterStatusMetric{
 				{
 					Status: 1.0,
 				},
@@ -234,7 +234,7 @@ func TestSystemCollector_CollectClusterStatusMetrics(t *testing.T) {
 				ManagementStatus: "sTaBLe",
 				Error:            nil,
 			},
-			expectedMetrics: []systemStatusMetric{
+			expectedMetrics: []clusterStatusMetric{
 				{
 					Status: 1.0,
 				},
@@ -247,7 +247,7 @@ func TestSystemCollector_CollectClusterStatusMetrics(t *testing.T) {
 				ManagementStatus: "STABLE",
 				Error:            nil,
 			},
-			expectedMetrics: []systemStatusMetric{
+			expectedMetrics: []clusterStatusMetric{
 				{
 					Status: 0.0,
 				},
@@ -260,7 +260,7 @@ func TestSystemCollector_CollectClusterStatusMetrics(t *testing.T) {
 				ManagementStatus: "UNSTABLE",
 				Error:            nil,
 			},
-			expectedMetrics: []systemStatusMetric{
+			expectedMetrics: []clusterStatusMetric{
 				{
 					Status: 0.0,
 				},
@@ -273,7 +273,7 @@ func TestSystemCollector_CollectClusterStatusMetrics(t *testing.T) {
 				ManagementStatus: "UNSTABLE",
 				Error:            nil,
 			},
-			expectedMetrics: []systemStatusMetric{
+			expectedMetrics: []clusterStatusMetric{
 				{
 					Status: 0.0,
 				},
@@ -286,7 +286,7 @@ func TestSystemCollector_CollectClusterStatusMetrics(t *testing.T) {
 				ManagementStatus: "DEGRADED",
 				Error:            nil,
 			},
-			expectedMetrics: []systemStatusMetric{
+			expectedMetrics: []clusterStatusMetric{
 				{
 					Status: 0.0,
 				},
@@ -299,7 +299,7 @@ func TestSystemCollector_CollectClusterStatusMetrics(t *testing.T) {
 				ManagementStatus: "UNKNOWN",
 				Error:            nil,
 			},
-			expectedMetrics: []systemStatusMetric{
+			expectedMetrics: []clusterStatusMetric{
 				{
 					Status: 0.0,
 				},
@@ -312,7 +312,7 @@ func TestSystemCollector_CollectClusterStatusMetrics(t *testing.T) {
 				ManagementStatus: "NO_CONTROLLERS",
 				Error:            nil,
 			},
-			expectedMetrics: []systemStatusMetric{
+			expectedMetrics: []clusterStatusMetric{
 				{
 					Status: 0.0,
 				},
@@ -325,7 +325,7 @@ func TestSystemCollector_CollectClusterStatusMetrics(t *testing.T) {
 				ManagementStatus: "STABLE",
 				Error:            errors.New("error read cluster status"),
 			},
-			expectedMetrics: []systemStatusMetric{},
+			expectedMetrics: []clusterStatusMetric{},
 		},
 	}
 	for _, tc := range testcases {

--- a/collector/system_collector_test.go
+++ b/collector/system_collector_test.go
@@ -341,10 +341,10 @@ func TestSystemCollector_CollectClusterStatusMetrics(t *testing.T) {
 
 func TestSystemCollector_CollectClusterNodeMetrics(t *testing.T) {
 	testcases := []struct {
-		description                   string
-		response                      mockClusterNodeStatusResponse
-		expectedControllerMetrics     []controllerNodeStatusMetric
-		expectedManagementNodeMetrics []managementNodeMetric
+		description                         string
+		response                            mockClusterNodeStatusResponse
+		expectedControllerNodeStatusMetrics []controllerNodeStatusMetric
+		expectedManagementNodeMetrics       []managementNodeMetric
 	}{
 		{
 			description: "Should return system metrics for management nodes and up value for connected nodes",
@@ -362,7 +362,7 @@ func TestSystemCollector_CollectClusterNodeMetrics(t *testing.T) {
 				ManagementClusterStatus: []string{"CONNECTED", "ConNected"},
 				Error:                   nil,
 			},
-			expectedControllerMetrics: []controllerNodeStatusMetric{
+			expectedControllerNodeStatusMetrics: []controllerNodeStatusMetric{
 				{
 					IPAddress:    fakeClusterNodeIPAddress,
 					StatusDetail: buildExpectedClusterNodeStatusDetail("CONNECTED"),
@@ -436,7 +436,7 @@ func TestSystemCollector_CollectClusterNodeMetrics(t *testing.T) {
 				ManagementClusterStatus: []string{"DISCONNECTED", "UNKNOWN"},
 				Error:                   nil,
 			},
-			expectedControllerMetrics: []controllerNodeStatusMetric{
+			expectedControllerNodeStatusMetrics: []controllerNodeStatusMetric{
 				{
 					IPAddress:    fakeClusterNodeIPAddress,
 					StatusDetail: buildExpectedClusterNodeStatusDetail("DISCONNECTED"),
@@ -514,7 +514,7 @@ func TestSystemCollector_CollectClusterNodeMetrics(t *testing.T) {
 		logger := log.NewNopLogger()
 		systemCollector := newSystemCollector(mockSystemClient, logger)
 		controllerNodeMetrics, nodeMetrics := systemCollector.collectClusterNodeMetrics()
-		assert.ElementsMatch(t, tc.expectedControllerMetrics, controllerNodeMetrics, tc.description)
+		assert.ElementsMatch(t, tc.expectedControllerNodeStatusMetrics, controllerNodeMetrics, tc.description)
 		assert.ElementsMatch(t, tc.expectedManagementNodeMetrics, nodeMetrics, tc.description)
 	}
 }


### PR DESCRIPTION
Change the system metric from the binary value to more detailed metrics to capture status enum.

Affected metric:
 - Management node status
 - Controller node status
 - System service status

Do some refactoring to achieve this including:
 - Separation of metric struct for the cluster, management node, controller node, and system service
 - Differentiate metric between controller and management node change from using string to struct

Signed-off-by: William Albertus Dembo <w.albertusd@gmail.com>