### PR TITLE
Expose type of NAT rules

### DIFF
--- a/collector/logical_router_collector.go
+++ b/collector/logical_router_collector.go
@@ -37,6 +37,7 @@ type logicalRouterStatusMetric struct {
 type natRuleStatisticMetric struct {
 	ID              string
 	Name            string
+	Type            string
 	LogicalRouterID string
 	NatTotalPackets float64
 	NatTotalBytes   float64
@@ -57,13 +58,13 @@ func newLogicalRouterCollector(logicalRouterClient client.LogicalRouterClient, l
 	natRuleTotalPackets := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "nat_rule", "total_packets"),
 		"Total packets processed by the NAT rule associated with logical router",
-		[]string{"id", "name", "logical_router_id"},
+		[]string{"id", "name", "type", "logical_router_id"},
 		nil,
 	)
 	natRuleTotalBytes := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "nat_rule", "total_bytes"),
 		"Total bytes processed by the NAT rule associated with logical router",
-		[]string{"id", "name", "logical_router_id"},
+		[]string{"id", "name", "type", "logical_router_id"},
 		nil,
 	)
 	return &logicalRouterCollector{
@@ -96,7 +97,7 @@ func (c *logicalRouterCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 	natRuleStatisticMetrics := c.generateNatRuleStatisticMetrics(logicalRouters)
 	for _, natMetric := range natRuleStatisticMetrics {
-		labels := []string{natMetric.ID, natMetric.Name, natMetric.LogicalRouterID}
+		labels := []string{natMetric.ID, natMetric.Name, natMetric.Type, natMetric.LogicalRouterID}
 		ch <- prometheus.MustNewConstMetric(c.natRuleTotalPackets, prometheus.GaugeValue, natMetric.NatTotalPackets, labels...)
 		ch <- prometheus.MustNewConstMetric(c.natRuleTotalBytes, prometheus.GaugeValue, natMetric.NatTotalBytes, labels...)
 	}
@@ -146,6 +147,7 @@ func (c *logicalRouterCollector) generateNatRuleStatisticMetrics(logicalRouters 
 			natRuleStatisticMetric := natRuleStatisticMetric{
 				ID:              rule.Id,
 				Name:            rule.DisplayName,
+				Type:            rule.Action,
 				LogicalRouterID: logicalRouter.Id,
 				NatTotalPackets: float64(statistic.TotalPackets),
 				NatTotalBytes:   float64(statistic.TotalBytes),

--- a/collector/logical_router_collector_test.go
+++ b/collector/logical_router_collector_test.go
@@ -17,6 +17,7 @@ const (
 	fakeLogicalRouterTransportNodeID = "fake-transport-node-id"
 	fakeNatRuleID                    = "fake-nat-rule-id"
 	fakeNatRuleName                  = "fake-nat-rule-name"
+	fakeNatRuleType                  = "fake-nat-rule-type"
 	fakeNatTotalPackets              = 1
 	fakeNatTotalBytes                = 1
 )
@@ -65,6 +66,7 @@ func (c *mockLogicalRouterClient) ListAllNatRules(lrouterID string) ([]manager.N
 			natRule := manager.NatRule{
 				Id:              rule.Id,
 				DisplayName:     rule.DisplayName,
+				Action:          rule.Action,
 				LogicalRouterId: lrouterID,
 			}
 			natRules = append(natRules, natRule)
@@ -118,6 +120,7 @@ func buildLogicalRouterResponseWithNatRules(lrouterID string, ruleIDs []string, 
 		natRules = append(natRules, manager.NatRule{
 			Id:          fmt.Sprintf("%s-%s", fakeNatRuleID, ruleID),
 			DisplayName: fmt.Sprintf("%s-%s", fakeNatRuleName, ruleID),
+			Action:      fakeNatRuleType,
 		})
 	}
 	return mockLogicalRouterResponse{
@@ -235,6 +238,7 @@ func TestLogicalRouterCollector_GenerateLogicalRouterNatStatisticMetrics(t *test
 				{
 					ID:              fmt.Sprintf("%s-1", fakeNatRuleID),
 					Name:            fmt.Sprintf("%s-1", fakeNatRuleName),
+					Type:            fakeNatRuleType,
 					LogicalRouterID: fmt.Sprintf("%s-1", fakeLogicalRouterID),
 					NatTotalPackets: fakeNatTotalPackets,
 					NatTotalBytes:   fakeNatTotalBytes,
@@ -242,6 +246,7 @@ func TestLogicalRouterCollector_GenerateLogicalRouterNatStatisticMetrics(t *test
 				{
 					ID:              fmt.Sprintf("%s-2", fakeNatRuleID),
 					Name:            fmt.Sprintf("%s-2", fakeNatRuleName),
+					Type:            fakeNatRuleType,
 					LogicalRouterID: fmt.Sprintf("%s-1", fakeLogicalRouterID),
 					NatTotalPackets: fakeNatTotalPackets,
 					NatTotalBytes:   fakeNatTotalBytes,
@@ -249,6 +254,7 @@ func TestLogicalRouterCollector_GenerateLogicalRouterNatStatisticMetrics(t *test
 				{
 					ID:              fmt.Sprintf("%s-3", fakeNatRuleID),
 					Name:            fmt.Sprintf("%s-3", fakeNatRuleName),
+					Type:            fakeNatRuleType,
 					LogicalRouterID: fmt.Sprintf("%s-2", fakeLogicalRouterID),
 					NatTotalPackets: fakeNatTotalPackets,
 					NatTotalBytes:   fakeNatTotalBytes,
@@ -265,6 +271,7 @@ func TestLogicalRouterCollector_GenerateLogicalRouterNatStatisticMetrics(t *test
 				{
 					ID:              fmt.Sprintf("%s-3", fakeNatRuleID),
 					Name:            fmt.Sprintf("%s-3", fakeNatRuleName),
+					Type:            fakeNatRuleType,
 					LogicalRouterID: fmt.Sprintf("%s-2", fakeLogicalRouterID),
 					NatTotalPackets: fakeNatTotalPackets,
 					NatTotalBytes:   fakeNatTotalBytes,


### PR DESCRIPTION
This commit exposes each NAT rule with the rule type,
i.e. SNAT, DNAT, NO_NAT, REFLEXIVE.

Address #72 

Signed-off-by: Giri Kuncoro <girikuncoro@gmail.com>